### PR TITLE
Remove generated blocks (plugin site link, adoption message, warnings)

### DIFF
--- a/StashBranchParameter/README.md
+++ b/StashBranchParameter/README.md
@@ -2,9 +2,3 @@
 
 This uses branches and tags as parameters. Hosting has moved to
 <https://github.com/jenkinsci/stash-branch-parameters-plugin>
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Passwords transmitted in plain
-    text](https://jenkins.io/security/advisory/2020-07-02/#SECURITY-1656)

--- a/TestFairy/README.md
+++ b/TestFairy/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                              |
-|-------------------------------------------------------------------------------------------------|
-| View TestFairy [on the plugin site](https://plugins.jenkins.io/TestFairy) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1062)
 
 This plugin helps you to upload Android APKs or iOS IPA files to
 [www.testfairy.com](http://www.testfairy.com/)

--- a/absint-astree/README.md
+++ b/absint-astree/README.md
@@ -1,13 +1,3 @@
-| Plugin Information                                                                                      |
-|---------------------------------------------------------------------------------------------------------|
-| View AbsInt Astrée [on the plugin site](https://plugins.jenkins.io/absint-astree) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Arbitrary file execution
-    vulnerability](https://jenkins.io/security/advisory/2018-06-04/#SECURITY-807)
-
 Integration of AbsInt's static code analyzer
 [Astrée](https://www.absint.com/astree) into the Jenkins continuous
 integration system

--- a/accelerated-build-now-plugin/README.md
+++ b/accelerated-build-now-plugin/README.md
@@ -3,14 +3,6 @@ a project's build right away, even if the queue is long (moving it to
 the top of the queue) and even if no executor is available (killing and
 rescheduling builds not launched by "humans")
 
-| Plugin Information                                                                                                                    |
-|---------------------------------------------------------------------------------------------------------------------------------------|
-| View accelerated-build-now-plugin [on the plugin site](https://plugins.jenkins.io/accelerated-build-now-plugin) for more information. |
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
-
 ## How to install :
 
 Download the [latest

--- a/amazon-ecr/README.md
+++ b/amazon-ecr/README.md
@@ -1,6 +1,3 @@
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plugin offers integration with Amazon EC2 Container Registry (ECR)
 as a DockerRegistryToken source to convert Amazon Credentials into a

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,18 +1,4 @@
-| Plugin Information                                                                          |
-|---------------------------------------------------------------------------------------------|
-| View Ansible [on the plugin site](https://plugins.jenkins.io/ansible) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Host key verification disabled by
-    default](https://jenkins.io/security/advisory/2018-03-26/#SECURITY-630)
--   [Missing permission checks allow enumerating credentials
-    IDs](https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-1943)
-
- 
-
- This plugin allows to execute [Ansible](http://www.ansible.com/) tasks
+This plugin allows to execute [Ansible](http://www.ansible.com/) tasks
 as a job build step.
 
 ## Table of Contents

--- a/app-detector/README.md
+++ b/app-detector/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Arbitrary code execution
-    vulnerability](https://jenkins.io/security/advisory/2017-04-10/)
 
 ## Features
 

--- a/appdynamics-dashboard/README.md
+++ b/appdynamics-dashboard/README.md
@@ -1,9 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-03-06/#SECURITY-1087)
-
 This plugin integrates with [AppDynamics](http://www.appdynamics.com/)
 to fetch measurements.
 

--- a/application-director-plugin/README.md
+++ b/application-director-plugin/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-09-25/#SECURITY-1541)
 
 Enables deployment of a cloud based application through [vFabric
 Application

--- a/artifactdeployer/README.md
+++ b/artifactdeployer/README.md
@@ -1,17 +1,3 @@
-| Plugin Information                                                                                             |
-|----------------------------------------------------------------------------------------------------------------|
-| View Artifact Deployer [on the plugin site](https://plugins.jenkins.io/artifactdeployer) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Arbitrary code execution
-    vulnerability](https://jenkins.io/security/advisory/2017-04-10/)
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
-
 This plugin makes it possible to copy artifacts to remote locations.
 
 # History and Objectives

--- a/assembla/README.md
+++ b/assembla/README.md
@@ -1,10 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-09-25/#SECURITY-1543)
-
-  
 
 This plugin integrates [Assembla](http://www.assembla.com/) to Jenkins.
 

--- a/async-http-client/README.md
+++ b/async-http-client/README.md
@@ -1,13 +1,3 @@
-| Plugin Information                                                                                              |
-|-----------------------------------------------------------------------------------------------------------------|
-| View Async Http Client [on the plugin site](https://plugins.jenkins.io/async-http-client) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Improper certificate
-    validation](https://jenkins.io/security/advisory/2016-06-20/)
-
 # Async Http Client Plugin
 
 This plugin provides a shared dependency on the ning.com

--- a/audit2db/README.md
+++ b/audit2db/README.md
@@ -1,11 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Audit to Database Plugin stores credentials in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-966)
--   [CSRF vulnerability and missing permission check allow connecting to
-    arbitrary
-    databases](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-977)
 
 Download latest release from
 [jenkins-ci.org](http://maven.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/audit2db/)

--- a/avatar/README.md
+++ b/avatar/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Missing permission check allows changing avatars of other
-    users](https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1099)
 
 This plugin allows avatar images to be uploaded and associated with
 Jenkins users.

--- a/aws-beanstalk-publisher-plugin/README.md
+++ b/aws-beanstalk-publisher-plugin/README.md
@@ -1,14 +1,5 @@
 Publish zip files to Amazon Web Service Elastic Beanstalk Applications.
 
-| Plugin Information                                                                                                                         |
-|--------------------------------------------------------------------------------------------------------------------------------------------|
-| View AWS Elastic Beanstalk Publisher [on the plugin site](https://plugins.jenkins.io/aws-beanstalk-publisher-plugin) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-831)
 
 # Amazon Web Services Elastic Beanstalk Publisher
 

--- a/aws-cloudwatch-logs-publisher/README.md
+++ b/aws-cloudwatch-logs-publisher/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                                                      |
-|-----------------------------------------------------------------------------------------------------------------------------------------|
-| View AWS CloudWatch Logs Publisher [on the plugin site](https://plugins.jenkins.io/aws-cloudwatch-logs-publisher) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [AWS CloudWatch Logs Publisher Plugin stores credentials in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-830)
 
   
 

--- a/aws-device-farm/README.md
+++ b/aws-device-farm/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-835)
 
 ## AWS Device Farm Plugin
 

--- a/aws-sqs/README.md
+++ b/aws-sqs/README.md
@@ -1,10 +1,3 @@
-| Plugin Information                                                                                        |
-|-----------------------------------------------------------------------------------------------------------|
-| View AWS SQS Build Trigger [on the plugin site](https://plugins.jenkins.io/aws-sqs) for more information. |
-
-**This plugin is up for adoption.** The maintainer is looking for a
-co-maintainer. [Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 Jenkins plugin that triggers builds on events that are published via
 Amazon Simple Queue Service (SQS)

--- a/awseb-deployment-plugin/README.md
+++ b/awseb-deployment-plugin/README.md
@@ -1,10 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Reflected XSS
-    vulnerability](https://jenkins.io/security/advisory/2020-04-07/#SECURITY-1769)
-
-  
 This plugin allows you to deploy into [AWS Elastic
 Beanstalk](http://aws.amazon.com/elasticbeanstalk/) by Packaging,
 Creating a new Application Version, and Updating an Environment

--- a/azure-acs/README.md
+++ b/azure-acs/README.md
@@ -1,9 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [RCE
-    vulnerability](https://jenkins.io/security/advisory/2020-03-25/#SECURITY-1732)
-
 A Jenkins Plugin to deploy configurations to Azure Container Service
 (AKS).
 

--- a/azure-event-grid-notifier/README.md
+++ b/azure-event-grid-notifier/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                                                    |
-|---------------------------------------------------------------------------------------------------------------------------------------|
-| View Azure Event Grid Build Notifier [on the plugin site](https://plugins.jenkins.io/azure-event-grid-notifier) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-09-25/#SECURITY-1544)
 
 Send build notifications to an Azure Event Grid Topic
 

--- a/azure-publishersettings-credentials/README.md
+++ b/azure-publishersettings-credentials/README.md
@@ -1,8 +1,2 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-17/#SECURITY-844)
-
 This plugin manage Azure PublisherSettings using Jenkins Crendentials
 API.

--- a/backup/README.md
+++ b/backup/README.md
@@ -1,6 +1,3 @@
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 Backup plugin allows archiving and restoring your Jenkins (and Hudson)
 home directory.

--- a/badge/README.md
+++ b/badge/README.md
@@ -1,13 +1,3 @@
-| Plugin Information                                                                      |
-|-----------------------------------------------------------------------------------------|
-| View Badge [on the plugin site](https://plugins.jenkins.io/badge) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Persisted cross-site scripting
-    vulnerability](https://jenkins.io/security/advisory/2018-06-25/#SECURITY-906)
-
  
 
 ## Readme

--- a/beaker-builder/README.md
+++ b/beaker-builder/README.md
@@ -1,9 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1545)
-
 This plugin ingrates Jenkins with [Beaker](http://beaker-project.org/).
 
   

--- a/bitbucket-approve/README.md
+++ b/bitbucket-approve/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Bitbucket Approve Plugin stores credentials in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-965)
 
 This Plugin enables Jenkins to approve commits on Bitbucket after
 successful builds.

--- a/bitbucket-oauth/README.md
+++ b/bitbucket-oauth/README.md
@@ -1,13 +1,3 @@
-| Plugin Information                                                                                          |
-|-------------------------------------------------------------------------------------------------------------|
-| View Bitbucket OAuth [on the plugin site](https://plugins.jenkins.io/bitbucket-oauth) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-10-23/#SECURITY-1546)
-
 This Jenkins plugin enables OAuth authentication for
 [Bitbucket](https://bitbucket.org/) users.
 

--- a/blackduck-detect/README.md
+++ b/blackduck-detect/README.md
@@ -2,12 +2,6 @@
 
 # Usage
 
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [CSRF vulnerability and lack of permission checks allows capturing
-    credentials](https://jenkins.io/security/advisory/2018-06-04/#SECURITY-866)
-
 ## Documentation
 
 [Synopsys Detect Jenkins plugin

--- a/bmc-rpd/README.md
+++ b/bmc-rpd/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                                     |
-|------------------------------------------------------------------------------------------------------------------------|
-| View BMC Release Package and Deployment [on the plugin site](https://plugins.jenkins.io/bmc-rpd) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credential stored in plain
-    text](https://jenkins.io/security/advisory/2020-02-12/#SECURITY-1547)
 
   
 The RPD Plugin integrates Jenkins with BMC Release Package and

--- a/bugzilla/README.md
+++ b/bugzilla/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-841)
 
 This plugin integrates [Bugzilla](http://www.bugzilla.org/) into
 Jenkins. It hyperlinks bug numbers that appear in changeset descriptions

--- a/build-environment/README.md
+++ b/build-environment/README.md
@@ -1,13 +1,3 @@
-| Plugin Information                                                                                              |
-|-----------------------------------------------------------------------------------------------------------------|
-| View Build Environment [on the plugin site](https://plugins.jenkins.io/build-environment) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Stored XSS
-    vulnerability](https://jenkins.io/security/advisory/2019-09-12/#SECURITY-1476)
-
 This plugin shows information about the environment of a build and gives
 the option to compare the environments of two builds.
 

--- a/build-failure-analyzer/README.md
+++ b/build-failure-analyzer/README.md
@@ -3,16 +3,6 @@ on the build page. It does this by using a knowledge base of build
 failure causes that is built up from scratch.  
 Saving statistics about failure causes is also possible.
 
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [CSRF vulnerability and missing permission check allow
-    ReDoS](https://jenkins.io/security/advisory/2019-12-17/#SECURITY-1651)
--   [XSS
-    vulnerability](https://jenkins.io/security/advisory/2020-09-01/#SECURITY-1770)
--   [Cross-site scripting
-    vulnerability](https://jenkins.io/security/advisory/2016-06-20/)
-
 ### Knowledge base
 
 The plugin comes with an empty knowledge base of failure causes.

--- a/build-metrics/README.md
+++ b/build-metrics/README.md
@@ -4,12 +4,6 @@ generate some basic build metrics.  It is really useful in combination
 with the [sidebar links
 plugin](http://localhost:8085/display/JENKINS/Sidebar-Link+Plugin).
 
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Reflected XSS
-    vulnerability](https://jenkins.io/security/advisory/2019-10-23/#SECURITY-1490)
-
 ## Requirements 
 
 This plugin requires Jenkins 1.509 or better and the [Global Build Stats

--- a/build-pipeline-plugin/README.md
+++ b/build-pipeline-plugin/README.md
@@ -6,16 +6,6 @@ offers the ability to define manual triggers for jobs that require
 intervention prior to execution, e.g. an approval process outside of
 Jenkins.
 
-| Plugin Information                                                                                               |
-|------------------------------------------------------------------------------------------------------------------|
-| View Build Pipeline [on the plugin site](https://plugins.jenkins.io/build-pipeline-plugin) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Stored XSS
-    vulnerability](https://jenkins.io/security/advisory/2019-08-07/#SECURITY-879)
-
 ### Release Notes
 
 1.5.8

--- a/build-publisher/README.md
+++ b/build-publisher/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                          |
-|-------------------------------------------------------------------------------------------------------------|
-| View Build-Publisher [on the plugin site](https://plugins.jenkins.io/build-publisher) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Insecure credential storage and
-    transmission](https://jenkins.io/security/advisory/2017-10-23/)
 
 # What does it do?
 

--- a/build-with-parameters/README.md
+++ b/build-with-parameters/README.md
@@ -1,10 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [CSRF
-    vulnerability](https://www.jenkins.io/security/advisory/2021-03-30/#SECURITY-2257)
--   [Stored XSS
-    vulnerability](https://www.jenkins.io/security/advisory/2021-03-30/#SECURITY-2231)
 
 Allows the user to provide parameters for a build in the url, prompting
 for confirmation before triggering the job.

--- a/buildgraph-view/README.md
+++ b/buildgraph-view/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Stored XSS
-    vulnerability](https://jenkins.io/security/advisory/2019-12-17/#SECURITY-1591)
 
 Shows a graph of builds that relates together (aka "build pipeline").
 

--- a/buildresult-trigger/README.md
+++ b/buildresult-trigger/README.md
@@ -1,6 +1,3 @@
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 BuildResultTrigger makes it possible to monitor the build results of
 other jobs.  

--- a/call-remote-job-plugin/README.md
+++ b/call-remote-job-plugin/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-09-25/#SECURITY-1548)
 
 # Description
 

--- a/chosen-views-tabbar/README.md
+++ b/chosen-views-tabbar/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Stored XSS
-    vulnerability](https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1869)
 
 Do you have too many views in your Jenkins? Do you get the dreaded
 horizontal scrolling? Then this plugin is for you!

--- a/clearcase-release/README.md
+++ b/clearcase-release/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Stored XSS
-    vulnerability](https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1911)
 
 This plugin makes it possible to promote composite baselines or latest
 baselines to RELEASED promotion level for Clearcase UCM.  

--- a/cloudcoreo-deploytime/README.md
+++ b/cloudcoreo-deploytime/README.md
@@ -1,14 +1,4 @@
-| Plugin Information                                                                                                      |
-|-------------------------------------------------------------------------------------------------------------------------|
-| View CloudCoreo DeployTime [on the plugin site](https://plugins.jenkins.io/cloudcoreo-deploytime) for more information. |
 
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-960)
-
- 
 
 # CloudCoreo DeployTime
 

--- a/cloudfoundry/README.md
+++ b/cloudfoundry/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                     |
-|--------------------------------------------------------------------------------------------------------|
-| View Cloud Foundry [on the plugin site](https://plugins.jenkins.io/cloudfoundry) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [CSRF vulnerability and missing permission checks allowed capturing
-    credentials](https://jenkins.io/security/advisory/2019-02-19/#SECURITY-876)
 
 Pushes a project to Cloud Foundry or a CF-based platform (e.g. Stackato)
 at the end of a build.

--- a/cloudshare-docker/README.md
+++ b/cloudshare-docker/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [CloudShare Docker-Machine Plugin stores credentials in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-838)
 
 Execute Docker commands on dedicated docker-machines on CloudShare,
 instead of running on the Jenkins host itself.

--- a/cloudtest/README.md
+++ b/cloudtest/README.md
@@ -3,18 +3,6 @@ CloudTest](http://www.soasta.com/products/cloudtest/) and [SOASTA
 TouchTest](http://www.soasta.com/products/touchtest/) features into
 Jenkins.
 
-| Plugin Information                                                                                     |
-|--------------------------------------------------------------------------------------------------------|
-| View SOASTA CloudTest [on the plugin site](https://plugins.jenkins.io/cloudtest) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [CSRF vulnerability and missing permission check allow
-    SSRF](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1054)
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-10-16/#SECURITY-1439)
-
 The CloudTest Jenkins plugin provides the ability to
 
 -   Easily run the MakeAppTouchTestable utility on an iOS or Android

--- a/cobertura/README.md
+++ b/cobertura/README.md
@@ -1,10 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Arbitrary file write
-    vulnerability](https://jenkins.io/security/advisory/2020-03-09/#SECURITY-1668)
--   [XXE
-    vulnerability](https://jenkins.io/security/advisory/2020-03-09/#SECURITY-1700)
 
 The current thinking is to merge this plugin into more generic coverage
 plugin. Help appreciated.

--- a/codebeamer-result-trend-updater/README.md
+++ b/codebeamer-result-trend-updater/README.md
@@ -8,12 +8,6 @@ Page](https://codebeamer.com/cb/project/1025).
 
  
 
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-03-25/#SECURITY-1086)
-
 Allows users to to update wiki pages in
 [codebeamer](http://intland.com/codebeamer/product-overview/) with test
 or performance results

--- a/codedeploy/README.md
+++ b/codedeploy/README.md
@@ -1,13 +1,5 @@
 # AWS Codedeploy plugin
 
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Serialization of potentially sensitive build
-    variables](https://jenkins.io/security/advisory/2018-06-25/#SECURITY-825)
--   [AWS Secret Key stored in plain
-    text](https://jenkins.io/security/advisory/2018-06-25/#SECURITY-833)
-
 The [AWS CodeDeploy](https://aws.amazon.com/codedeploy) Jenkins plugin
 provides a post-build step for your Jenkins project. Upon a successful
 build, it will zip the workspace, upload to S3, and  

--- a/codefresh/README.md
+++ b/codefresh/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                          |
-|-------------------------------------------------------------------------------------------------------------|
-| View Codefresh Integration [on the plugin site](https://plugins.jenkins.io/codefresh) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [SSL/TLS certificate validation globally and unconditionally
-    disabled](https://jenkins.io/security/advisory/2019-08-07/#SECURITY-931)
 
 ![](docs/images/codefresh_logo_f_left-nc_(1).png){width="400"}
 

--- a/compatibility-action-storage/README.md
+++ b/compatibility-action-storage/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Reflected
-    XSS](https://jenkins.io/security/advisory/2020-07-02/#SECURITY-1771)
 
 #### Developed by
 
@@ -25,12 +20,6 @@ Data cannot be retrieved due to an unexpected error.
 
 [View these issues in
 Jira](http://issues.jenkins-ci.org/secure/IssueNavigator.jspa?reset=true&jqlQuery=project%20=%20JENKINS%20AND%20status%20in%20%28Open,%20%22In%20Progress%22,%20Reopened%29%20AND%20component%20=%20%27compatibility-action-storage-plugin%27&src=confmacro)
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Reflected
-    XSS](https://jenkins.io/security/advisory/2020-07-02/#SECURITY-1771)
 
 #### Developed by
 

--- a/computer-queue-plugin/README.md
+++ b/computer-queue-plugin/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Stored XSS
-    vulnerability](https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1912)
 
 This plug-in display the queue for given computer in it's page
 

--- a/console-column-plugin/README.md
+++ b/console-column-plugin/README.md
@@ -5,12 +5,6 @@ Minimum Version
 Because of a JDK issue, requiredCore was made to be 1.420. However, we
 have reports that this plugin will happily work on 1.409 LTS releases.
 
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
-
-  
-
 Provide a fast-path console link available for views.
 
   

--- a/console-tail/README.md
+++ b/console-tail/README.md
@@ -1,6 +1,3 @@
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 # Console Tail Plugin
 

--- a/copr/README.md
+++ b/copr/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2020-04-16/#SECURITY-1556)
 
 # Copr plugin
 

--- a/copy-data-to-workspace-plugin/README.md
+++ b/copy-data-to-workspace-plugin/README.md
@@ -1,14 +1,4 @@
-| Plugin Information                                                                                                               |
-|----------------------------------------------------------------------------------------------------------------------------------|
-| View Copy data to workspace [on the plugin site](https://plugins.jenkins.io/copy-data-to-workspace-plugin) for more information. |
 
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Arbitrary file read
-    vulnerability](https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1966)
-
-  
 
 Copies data to workspace directory for each project build.
 

--- a/couchdb-statistics/README.md
+++ b/couchdb-statistics/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Password stored in plain
-    text](https://www.jenkins.io/security/advisory/2020-10-08/#SECURITY-2065)
 
 CouchDB Statistics plugin allows the publishing of all build statistics
 to CouchDB/Cloudant.

--- a/covcomplplot/README.md
+++ b/covcomplplot/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Stored XSS
-    vulnerability](https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1913)
 
 This plugin shows the coverage/complexity scatter plot from Clover or
 Cobertura plugin results.

--- a/coverity/README.md
+++ b/coverity/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Keystore and private key passwords stored in plain
-    text](https://jenkins.io/security/advisory/2018-02-26/#SECURITY-260)
 
 This plugin integrates Jenkins with the [Coverity
 Connect](http://www.coverity.com/products/coverity-connect/) and

--- a/cppncss/README.md
+++ b/cppncss/README.md
@@ -1,16 +1,3 @@
-| Plugin Information                                                                          |
-|---------------------------------------------------------------------------------------------|
-| View CppNCSS [on the plugin site](https://plugins.jenkins.io/cppncss) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Reflected cross-site-scripting
-    vulnerability](https://jenkins.io/security/advisory/2018-02-26/#SECURITY-712)
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plugin allows you to use [CppNCSS](http://cppncss.sourceforge.net/)
 build reporting tool.

--- a/crittercism-dsym/README.md
+++ b/crittercism-dsym/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [API key stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1063)
 
 A Jenkins CI plugin for uploading dSYM files to Crittercism.
 

--- a/crowd/README.md
+++ b/crowd/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Crowd Integration Plugin stores credentials in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1069)
 
 # Crowd plugin
 

--- a/crowd2/README.md
+++ b/crowd2/README.md
@@ -1,18 +1,3 @@
-| Plugin Information                                                                                     |
-|--------------------------------------------------------------------------------------------------------|
-| View Crowd 2 Integration [on the plugin site](https://plugins.jenkins.io/crowd2) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2018-09-25/#SECURITY-1068)
--   [SSRF
-    vulnerability](https://jenkins.io/security/advisory/2018-09-25/#SECURITY-1067)
-
-**This plugin is up for adoption.** The maintainer is looking for a
-co-maintainer or successor. [Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 # Crowd 2 Plugin
 

--- a/crx-content-package-deployer/README.md
+++ b/crx-content-package-deployer/README.md
@@ -1,14 +1,3 @@
-| Plugin Information                                                                                                                    |
-|---------------------------------------------------------------------------------------------------------------------------------------|
-| View CRX Content Package Deployer [on the plugin site](https://plugins.jenkins.io/crx-content-package-deployer) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Users with Overall/Read access could enumerate credential
-    IDs](https://jenkins.io/security/advisory/2019-10-16/#SECURITY-1006%20(2))
--   [CSRF vulnerability and missing permission check allow capturing
-    credentials](https://jenkins.io/security/advisory/2019-10-16/#SECURITY-1006%20(1))
 
 # CRX Content Package Deployer Plugin
 

--- a/cucumber-slack-notifier/README.md
+++ b/cucumber-slack-notifier/README.md
@@ -1,6 +1,3 @@
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 A plugin to send a summarised cucumber report to a slack channel.
 

--- a/cucumber-testresult-plugin/README.md
+++ b/cucumber-testresult-plugin/README.md
@@ -1,10 +1,3 @@
-| Plugin Information                                                                                                                  |
-|-------------------------------------------------------------------------------------------------------------------------------------|
-| View Cucumber json test reporting [on the plugin site](https://plugins.jenkins.io/cucumber-testresult-plugin) for more information. |
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plugin allows you to show the results of [Cucumber
 tests](http://cukes.info/) within Jenkins.

--- a/custom-job-icon/README.md
+++ b/custom-job-icon/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Stored XSS
-    vulnerability](https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1914)
 
 This plugin allows to configure a custom icon for each job in order to
 improve the job visibility on the dashboard.

--- a/cygwin-process-killer/README.md
+++ b/cygwin-process-killer/README.md
@@ -1,10 +1,3 @@
-| Plugin Information                                                                                                      |
-|-------------------------------------------------------------------------------------------------------------------------|
-| View Cygwin Process Killer [on the plugin site](https://plugins.jenkins.io/cygwin-process-killer) for more information. |
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 Plugin implements proper termination of Cygwin processes in Jenkins jobs
 

--- a/debian-package-builder/README.md
+++ b/debian-package-builder/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2020-02-12/#SECURITY-1558)
 
 This plugin helps building debian (.deb) packages
 

--- a/delivery-pipeline-plugin/README.md
+++ b/delivery-pipeline-plugin/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                                     |
-|------------------------------------------------------------------------------------------------------------------------|
-| View Delivery Pipeline [on the plugin site](https://plugins.jenkins.io/delivery-pipeline-plugin) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Reflected cross-site scripting
-    vulnerability](https://jenkins.io/security/advisory/2017-11-16/)
 
 # Summary
 

--- a/delphix/README.md
+++ b/delphix/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                          |
-|---------------------------------------------------------------------------------------------|
-| View Delphix [on the plugin site](https://plugins.jenkins.io/delphix) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-10-16/#SECURITY-1450)
 
 [  
 ![Build

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                     |
-|--------------------------------------------------------------------------------------------------------|
-| View Deploy to container [on the plugin site](https://plugins.jenkins.io/deploy) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Insecure credential
-    storage](https://jenkins.io/security/advisory/2017-08-07/)
 
 This plugin takes a war/ear file and deploys that to a running remote
 application server at the end of a build. The implementation is based on

--- a/deployed-on-column/README.md
+++ b/deployed-on-column/README.md
@@ -1,10 +1,3 @@
-| Plugin Information                                                                                                |
-|-------------------------------------------------------------------------------------------------------------------|
-| View Deployed On Column [on the plugin site](https://plugins.jenkins.io/deployed-on-column) for more information. |
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 # Deployed on Column Plugin
 

--- a/deployer-framework/README.md
+++ b/deployer-framework/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                                |
-|-------------------------------------------------------------------------------------------------------------------|
-| View Deployer Framework [on the plugin site](https://plugins.jenkins.io/deployer-framework) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Stored XSS
-    vulnerability](https://jenkins.io/security/advisory/2020-07-15/#SECURITY-1915)
 
 # Deployer Framework Plugin
 

--- a/deployment-sphere/README.md
+++ b/deployment-sphere/README.md
@@ -1,6 +1,3 @@
-| Plugin Information                                                                                              |
-|-----------------------------------------------------------------------------------------------------------------|
-| View Deployment Sphere [on the plugin site](https://plugins.jenkins.io/deployment-sphere) for more information. |
 
 Jenkins plugin to have a bird's eye view of your continuous deployment
 pipeline.

--- a/description-column-plugin/README.md
+++ b/description-column-plugin/README.md
@@ -1,13 +1,5 @@
 # Description Column Plugin
 
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Stored XSS
-    vulnerability](https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1916)
-
-  
-
 Provide job description column for views.
 
 ## Configuration

--- a/diawi-upload/README.md
+++ b/diawi-upload/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                    |
-|-------------------------------------------------------------------------------------------------------|
-| View Diawi Upload [on the plugin site](https://plugins.jenkins.io/diawi-upload) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-947)
 
 ## Features
 

--- a/distfork/README.md
+++ b/distfork/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Missing permission checks allowed shell access to anonymous
-    users](https://jenkins.io/security/advisory/2017-03-20/)
 
 Turns a Jenkins cluster into a general purpose batch job execution
 environment through an SSH-like CLI.

--- a/downstream-buildview/README.md
+++ b/downstream-buildview/README.md
@@ -1,6 +1,3 @@
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plugin allows you to view the full status all the downstream builds
 so that we can graphically see that everything for this build has been

--- a/dynamic-search-view/README.md
+++ b/dynamic-search-view/README.md
@@ -1,14 +1,6 @@
 Adds a new list view, which allows to dynamically specify additional
 filters.
 
-| Plugin Information                                                                                                  |
-|---------------------------------------------------------------------------------------------------------------------|
-| View Dynamic Search View [on the plugin site](https://plugins.jenkins.io/dynamic-search-view) for more information. |
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
-
 # About this plugin
 
 Dynamic Search View allows setting of additional filters at the view’s

--- a/dynamic_extended_choice_parameter/README.md
+++ b/dynamic_extended_choice_parameter/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Password stored in plain
-    text](https://jenkins.io/security/advisory/2020-02-12/#SECURITY-1560)
 
 Adds Dynamic functionality to Extended Choice parameter plugin.
 

--- a/eagle-tester/README.md
+++ b/eagle-tester/README.md
@@ -2,12 +2,6 @@ This plugin enables use of [Eagle
 Tester](https://tester.mobileenerlytics.com/) for identifying,
 prioritising and managing app battery drain for every app release.
 
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Password stored in plain
-    text](https://jenkins.io/security/advisory/2020-02-12/#SECURITY-1552)
-
 # Using the plugin
 
 Most up-to date information can be found

--- a/eggplant-plugin/README.md
+++ b/eggplant-plugin/README.md
@@ -11,16 +11,6 @@ the on-line documentation:
 
  
 
-| Plugin Information                                                                                   |
-|------------------------------------------------------------------------------------------------------|
-| View eggPlant [on the plugin site](https://plugins.jenkins.io/eggplant-plugin) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1430)
-
 This plugin calls Eggplant scripts as a Jenkins Build Action and returns
 the results to Jenkins for review or further processing.
 

--- a/elOyente/README.md
+++ b/elOyente/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-09-25/#SECURITY-1561)
 
 This plug-in adds job triggering based on XMPP Pub/Sub events.
 

--- a/elastest/README.md
+++ b/elastest/README.md
@@ -1,14 +1,3 @@
-| Plugin Information                                                                            |
-|-----------------------------------------------------------------------------------------------|
-| View ElasTest [on the plugin site](https://plugins.jenkins.io/elastest) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [CSRF vulnerability and missing permission
-    checks](https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1903)
--   [Passwords stored in plain
-    text](https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-2014)
 
 # Description
 

--- a/elasticbox/README.md
+++ b/elasticbox/README.md
@@ -13,14 +13,6 @@ The plugin is always compatible with the latest version of ElasticBox.
 If you're using a previous version of ElasticBox (\<4.0), the latest
 compatible version of the plugin is the 0.9.14
 
-  
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-10-16/#SECURITY-1434)
-
 The latest documentation and tutorials can be found at
 <https://elasticbox.com/documentation/integrate-with-jenkins/ci-cd-overview/>
 

--- a/extended-choice-parameter/README.md
+++ b/extended-choice-parameter/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Arbitrary code execution
-    vulnerability](https://jenkins.io/security/advisory/2017-04-10/)
 
 Adds extended functionality to Choice parameter.
 

--- a/extension-filter/README.md
+++ b/extension-filter/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                            |
-|---------------------------------------------------------------------------------------------------------------|
-| View extension-filter [on the plugin site](https://plugins.jenkins.io/extension-filter) for more information. |
-
-**This plugin is up for adoption.** This plugin is looking for a new
-maintainer!
-![](docs/images/smile.png){width="16"
-height="16"} [Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plugin allows to filter features available on a Jenkins instance by
 disabling some Extensions/Descriptors.

--- a/extensivetesting/README.md
+++ b/extensivetesting/README.md
@@ -1,11 +1,5 @@
 Allow you to run eXtensive Testing tests before or after a build.
 
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-10-16/#SECURITY-1432)
-
 Log test steps into log file on the project workspace.  
 Show results in HTML page.  
 Store results into the project workspace.

--- a/fabric-beta-publisher/README.md
+++ b/fabric-beta-publisher/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                                      |
-|-------------------------------------------------------------------------------------------------------------------------|
-| View Fabric Beta Publisher [on the plugin site](https://plugins.jenkins.io/fabric-beta-publisher) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1043)
 
 Allows users to publish Android apps to [Fabric
 Beta](https://docs.fabric.io/android/beta/overview.html)

--- a/favorite/README.md
+++ b/favorite/README.md
@@ -1,10 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Missing permission check allows anyone to change favorites for any
-    other user](https://jenkins.io/security/advisory/2017-06-06/)
--   [CSRF vulnerability allows changing another user's
-    favorites](https://jenkins.io/security/advisory/2017-06-06/)
 
 This plugin allows you to mark a job a favorite.This is controlled via a
 list view column you need to add to a view. You can then click on a star

--- a/filesystem_scm/README.md
+++ b/filesystem_scm/README.md
@@ -1,19 +1,5 @@
 Use File System as SCM.
 
-| Plugin Information                                                                                         |
-|------------------------------------------------------------------------------------------------------------|
-| View File System SCM [on the plugin site](https://plugins.jenkins.io/filesystem_scm) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Arbitrary file read
-    vulnerability](https://jenkins.io/security/advisory/2019-08-07/#SECURITY-569)
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
-
 Simulate File System as SCM by checking file system last modified date,
 checkout(), pollChanges(), ChangeLog and distributed build are all
 supported.

--- a/ftppublisher/README.md
+++ b/ftppublisher/README.md
@@ -1,11 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-954)
--   [CSRF vulnerability and missing permission check allow connecting to
-    arbitrary FTP
-    servers](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-974)
 
 This plugin can be used to upload project artifacts and whole
 directories to an ftp server. The following image show the configuration

--- a/gatling/README.md
+++ b/gatling/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [XSS
-    vulnerability](https://jenkins.io/security/advisory/2020-04-07/#SECURITY-1633)
 
 This plugin integrates [Gatling](http://gatling.io/), an Open Source
 stress tool, with Jenkins.

--- a/gcal/README.md
+++ b/gcal/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-09-25/#SECURITY-1572)
 
 # What's this?
 

--- a/gem-publisher/README.md
+++ b/gem-publisher/README.md
@@ -1,7 +1,2 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-09-25/#SECURITY-1573)
 
 This plugin lets you publish rubygems to rubygems.org using their API.

--- a/ghprb/README.md
+++ b/ghprb/README.md
@@ -3,24 +3,6 @@ Plugin](http://localhost:8085/display/JENKINS/GitHub+Branch+Source+Plugin)
 
 This plugin builds pull requests in github and report results.
 
-| Plugin Information                                                                                            |
-|---------------------------------------------------------------------------------------------------------------|
-| View GitHub Pull Request Builder [on the plugin site](https://plugins.jenkins.io/ghprb) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [GitHub access tokens stored in
-    build.xml](https://jenkins.io/security/advisory/2018-03-26/#SECURITY-261)
--   [Webhook secret stored in plain
-    text](https://jenkins.io/security/advisory/2018-03-26/#SECURITY-262)
--   [CSRF vulnerability and lack of permission checks allows capturing
-    credentials](https://jenkins.io/security/advisory/2018-06-04/#SECURITY-805)
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
-
 More **up to date** information is available on the:  
 [Github
 README.md](https://github.com/jenkinsci/ghprb-plugin/blob/master/README.md)

--- a/git-parameter/README.md
+++ b/git-parameter/README.md
@@ -1,14 +1,3 @@
-| Plugin Information                                                                                      |
-|---------------------------------------------------------------------------------------------------------|
-| View Git Parameter [on the plugin site](https://plugins.jenkins.io/git-parameter) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Stored XSS
-    vulnerability](https://jenkins.io/security/advisory/2020-09-01/#SECURITY-1884)
--   [Multiple stored XSS
-    vulnerabilities](https://jenkins.io/security/advisory/2020-02-12/#SECURITY-1709)
 
 ### Adds ability to choose branches, tags or revisions from git repository configured in project.
 

--- a/git-prebuildmerge-trait/README.md
+++ b/git-prebuildmerge-trait/README.md
@@ -1,17 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [CSRF vulnerability in Git plugin allows capturing
-    credentials](https://jenkins.io/security/advisory/2017-07-10/)
--   [CSRF
-    vulnerability](https://jenkins.io/security/advisory/2019-01-28/#SECURITY-1095)
--   [Stored XSS
-    vulnerability](https://jenkins.io/security/advisory/2020-03-09/#SECURITY-1723)
--   [Server-side request
-    forgery](https://jenkins.io/security/advisory/2018-06-04/#SECURITY-810)
--   [Users without Overall/Read are able to access lists of user names
-    and node
-    names](https://jenkins.io/security/advisory/2018-02-26/#SECURITY-723)
 
 This plugin allows use of [Git](http://git-scm.com/) as a build SCM,
 including repository browsers for several providers. A recent Git

--- a/github-oauth/README.md
+++ b/github-oauth/README.md
@@ -4,20 +4,6 @@ The GitHub Authentication Plugin provides a means of using GitHub for
 authentication and authorization to secure Jenkins. GitHub Enterprise is
 also supported.
 
-| Plugin Information                                                                                             |
-|----------------------------------------------------------------------------------------------------------------|
-| View GitHub Authentication [on the plugin site](https://plugins.jenkins.io/github-oauth) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [CSRF vulnerability in OAuth
-    callback](https://jenkins.io/security/advisory/2019-04-30/#SECURITY-443)
--   [Client secret displayed in plain
-    text](https://jenkins.io/security/advisory/2019-01-28/#SECURITY-602)
--   [Session fixation
-    vulnerability](https://jenkins.io/security/advisory/2019-01-28/#SECURITY-797)
-
 **On this page:**
 
 ## Setup

--- a/gitlab-hook/README.md
+++ b/gitlab-hook/README.md
@@ -1,10 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Reflected XSS
-    vulnerability](https://jenkins.io/security/advisory/2020-01-15/#SECURITY-1683)
--   [Gitlab API token stored and displayed in plain
-    text](https://jenkins.io/security/advisory/2018-05-09/#SECURITY-263)
 
 Enables Gitlab web hooks to be used to trigger SMC polling on Gitlab
 projects

--- a/gitlab-logo/README.md
+++ b/gitlab-logo/README.md
@@ -2,16 +2,6 @@
 
 Display GitLab Repository Icon on dashboard
 
-| Plugin Information                                                                                  |
-|-----------------------------------------------------------------------------------------------------|
-| View GitLab Logo [on the plugin site](https://plugins.jenkins.io/gitlab-logo) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-09-25/#SECURITY-1575)
-
 [![](http://sebastian-badge.info/plugins/gitlab-logo.svg)](https://wiki.jenkins-ci.org/display/JENKINS/GitLab+Logo+Plugin)
 [![](https://jenkins.ci.cloudbees.com/buildStatus/icon?job=plugins/gitlab-logo-plugin)](https://jenkins.ci.cloudbees.com/job/plugins/job/gitlab-logo-plugin/)
 

--- a/global-build-stats/README.md
+++ b/global-build-stats/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                                |
-|-------------------------------------------------------------------------------------------------------------------|
-| View global-build-stats [on the plugin site](https://plugins.jenkins.io/global-build-stats) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [CSRF and XSS
-    vulnerabilities](https://jenkins.io/security/advisory/2017-10-23/)
 
 Global build stats plugin will allow to gather and display global build
 result statistics.  

--- a/global-post-script/README.md
+++ b/global-post-script/README.md
@@ -7,12 +7,6 @@ the parameterized jobs.
 
 **Notice: jython script support removed since 1.1.0**
 
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Missing permission check allowed obtaining configuration
-    data](https://jenkins.io/security/advisory/2019-10-23/#SECURITY-1073)
-
 # Global Configure
 
 ![](docs/images/global-config.png)  

--- a/gnat/README.md
+++ b/gnat/README.md
@@ -1,14 +1,4 @@
- 
 
-| Plugin Information                                                                    |
-|---------------------------------------------------------------------------------------|
-| View GNAT [on the plugin site](https://plugins.jenkins.io/gnat) for more information. |
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
-
-  
 This plugin makes it possible to integrate
 [Gnat](http://www.adacore.com/home/products/gnatpro/toolsuite/tool_partners/)
 features for Ada languages in Jenkins.  

--- a/gogs-webhook/README.md
+++ b/gogs-webhook/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1438)
 
 Allows users to use the [Gogs](https://gogs.io/) Webhook
 

--- a/google-login/README.md
+++ b/google-login/README.md
@@ -1,16 +1,3 @@
-| Plugin Information                                                                                    |
-|-------------------------------------------------------------------------------------------------------|
-| View Google Login [on the plugin site](https://plugins.jenkins.io/google-login) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Authentication bypass
-    vulnerability](https://jenkins.io/security/advisory/2015-10-12/)
--   [Open redirect
-    vulnerability](https://jenkins.io/security/advisory/2018-04-16/#SECURITY-684)
--   [Session fixation
-    vulnerability](https://jenkins.io/security/advisory/2018-04-16/#SECURITY-442)
 
 # Google Login Plugin
 

--- a/groovy-label-assignment/README.md
+++ b/groovy-label-assignment/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                                          |
-|-----------------------------------------------------------------------------------------------------------------------------|
-| View Groovy Label Assignment [on the plugin site](https://plugins.jenkins.io/groovy-label-assignment) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Arbitrary code execution
-    vulnerability](https://jenkins.io/security/advisory/2017-04-10/)
 
 Provides "Groovy script to restrict where this project can be run" in
 job configuration pages.

--- a/groovy-postbuild/README.md
+++ b/groovy-postbuild/README.md
@@ -1,10 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Persisted cross-site scripting vulnerability in build
-    badges](https://jenkins.io/security/advisory/2018-05-09/#SECURITY-821)
--   [Arbitrary code execution
-    vulnerability](https://jenkins.io/security/advisory/2017-04-10/)
 
 This plugin executes a groovy script in the Jenkins JVM. Typically, the
 script checks some conditions and changes accordingly the build result,

--- a/harvest/README.md
+++ b/harvest/README.md
@@ -1,16 +1,3 @@
-| Plugin Information                                                                              |
-|-------------------------------------------------------------------------------------------------|
-| View Harvest SCM [on the plugin site](https://plugins.jenkins.io/harvest) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Passwords stored in plain
-    text](https://jenkins.io/security/advisory/2020-02-12/#SECURITY-1553)
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plugin allows you to use [CA
 Harvest](http://www.ca.com/us/products/product.aspx?id=255) as a SCM.

--- a/hipchat/README.md
+++ b/hipchat/README.md
@@ -1,15 +1,3 @@
-| Plugin Information                                                                          |
-|---------------------------------------------------------------------------------------------|
-| View HipChat [on the plugin site](https://plugins.jenkins.io/hipchat) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Unprivileged users with Overall/Read access are able to enumerate
-    credential
-    IDs](https://jenkins.io/security/advisory/2018-09-25/#SECURITY-984%20%282%29)
--   [CSRF vulnerability and missing permission checks allowed capturing
-    credentials](https://jenkins.io/security/advisory/2018-09-25/#SECURITY-984%20%281%29)
 
 For detailed instructions on how to use this plugin please see the
 [GitHub

--- a/hp-quality-center/README.md
+++ b/hp-quality-center/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                                  |
-|---------------------------------------------------------------------------------------------------------------------|
-| View HP ALM Quality Center [on the plugin site](https://plugins.jenkins.io/hp-quality-center) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Password stored in plain
-    text](https://jenkins.io/security/advisory/2020-07-02/#SECURITY-1576)
 
 Allows users to synchronize test results from Jenkins with HP ALM
 Quality Center.

--- a/hyper-commons/README.md
+++ b/hyper-commons/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Hyper.sh Commons Plugin stores credentials in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-964)
 
 This plugin provides common functions for other hyper plugins.
 

--- a/icescrum/README.md
+++ b/icescrum/README.md
@@ -1,14 +1,3 @@
-| Plugin Information                                                                            |
-|-----------------------------------------------------------------------------------------------|
-| View iceScrum [on the plugin site](https://plugins.jenkins.io/icescrum) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-10-16/#SECURITY-1436)
--   [CSRF vulnerability and missing permission
-    check](https://jenkins.io/security/advisory/2019-10-16/#SECURITY-1484)
 
 iceScrum is a web application for using Scrum while keeping the spirit
 of a collaborative workspace. It also offers virtual boards with

--- a/implied-labels/README.md
+++ b/implied-labels/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Missing permission check allows reconfiguring the
-    plugin](https://www.jenkins.io/security/advisory/2020-09-23/#SECURITY-2004)
 
 # Implied Labels Plugin
 

--- a/ivytrigger/README.md
+++ b/ivytrigger/README.md
@@ -1,6 +1,3 @@
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 IvyTrigger provides polling mechanisms to poll an Ivy file and triggers
 a build if an Ivy dependency version has changed.  

--- a/jabber-server-plugin/README.md
+++ b/jabber-server-plugin/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1031)
 
 This plugin creates a Jabber-Server for your builtin-users using the
 Jenkin's Domainname (you need a .jks-File).

--- a/jabber/README.md
+++ b/jabber/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                                    |
-|-----------------------------------------------------------------------------------------------------------------------|
-| View Jabber (XMPP) notifier and control [on the plugin site](https://plugins.jenkins.io/jabber) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Passwords stored in plain
-    text](https://www.jenkins.io/security/advisory/2021-03-30/#SECURITY-2162)
 
 Integrates Jenkins with the Jabber/XMPP instant messaging protocol. Note
 that you also need to install the [instant-messaging

--- a/javancss/README.md
+++ b/javancss/README.md
@@ -1,6 +1,3 @@
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plugin allows you to use
 [JavaNCSS](http://www.kclee.de/clemens/java/javancss/) build reporting

--- a/jenkins-cloudformation-plugin/README.md
+++ b/jenkins-cloudformation-plugin/README.md
@@ -1,12 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1042)
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 A plugin that allows for the creation of cloud formation stacks before
 running the build and the deletion of them after the build is completed.

--- a/jenkins-jira-issue-updater/README.md
+++ b/jenkins-jira-issue-updater/README.md
@@ -1,14 +1,6 @@
 I see only questions and no answers. Does anybody answers these
 questions? Otherwise what is the point to ask?
 
-  
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-837)
-
 This is a Jenkins plugin which updates issues in Atlassian JIRA (by
 changing their status, adding a comment or updating fields) as part of a
 Jenkins job.

--- a/jenkins-reviewbot/README.md
+++ b/jenkins-reviewbot/README.md
@@ -1,16 +1,3 @@
-| Plugin Information                                                                                              |
-|-----------------------------------------------------------------------------------------------------------------|
-| View jenkins-reviewbot [on the plugin site](https://plugins.jenkins.io/jenkins-reviewbot) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [CSRF vulnerability and missing permission check allow
-    SSRF](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1091)
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plugin pulls a diff from reviewboard request, applies the patch,
 builds it and reports the build status as a review comment

--- a/jenkinsci-appspider-plugin/README.md
+++ b/jenkinsci-appspider-plugin/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Password stored in plain
-    text](https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2058)
 
 The Appspider plugin allows you to configure settings to automatically
 trigger Appspider scans when builds of your web application completes.

--- a/jenkinswalldisplay/README.md
+++ b/jenkinswalldisplay/README.md
@@ -1,10 +1,4 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
 
--   [Reflected XSS
-    vulnerability](https://jenkins.io/security/advisory/2019-08-07/#SECURITY-751)
-
-  
 A wall display that shows job build progress in a way suitable for
 public wall displays. Rendering is performed using javascript based on
 REST API calls, so requires no page refreshes. 

--- a/jira-ext/README.md
+++ b/jira-ext/README.md
@@ -3,16 +3,6 @@
 A plugin for Jenkins CI to update JIRA tickets in an extensible way:
 both what to update and how to up date are exposed as Extension Points
 
-| Plugin Information                                                                            |
-|-----------------------------------------------------------------------------------------------|
-| View jira-ext [on the plugin site](https://plugins.jenkins.io/jira-ext) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-17/#SECURITY-836)
-
 # Release Notes
 
 0.8 March 23 2019

--- a/jira-trigger/README.md
+++ b/jira-trigger/README.md
@@ -1,10 +1,3 @@
-| Plugin Information                                                                                    |
-|-------------------------------------------------------------------------------------------------------|
-| View JIRA Trigger [on the plugin site](https://plugins.jenkins.io/jira-trigger) for more information. |
-
-**This plugin is up for adoption.** The maintainer is looking for a
-co-maintainer. [Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 Triggers a build when a certain condition is matched in JIRA.
 

--- a/job-import-plugin/README.md
+++ b/job-import-plugin/README.md
@@ -1,19 +1,5 @@
 # Job Import Plugin
 
-| Plugin Information                                                                                       |
-|----------------------------------------------------------------------------------------------------------|
-| View Job Import [on the plugin site](https://plugins.jenkins.io/job-import-plugin) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [CSRF
-    vulnerability](https://jenkins.io/security/advisory/2019-01-28/#SECURITY-1302)
--   [XXE
-    vulnerability](https://jenkins.io/security/advisory/2019-01-28/#SECURITY-905%20%281%29)
--   [CSRF
-    vulnerability](https://jenkins.io/security/advisory/2019-01-28/#SECURITY-905%20%282%29)
-
 Import jobs from another Jenkins instance.  
 
 ------------------------------------------------------------------------

--- a/job-node-stalker/README.md
+++ b/job-node-stalker/README.md
@@ -1,6 +1,3 @@
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 ![](docs/images/dlex.jpg){width="200"}
 

--- a/job-restrictions/README.md
+++ b/job-restrictions/README.md
@@ -1,10 +1,3 @@
-| Plugin Information                                                                                            |
-|---------------------------------------------------------------------------------------------------------------|
-| View Job Restrictions [on the plugin site](https://plugins.jenkins.io/job-restrictions) for more information. |
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 The plugin allows restricting job executions in order to change their
 behavior or to harden the security. With this plugin it is possible to

--- a/jquery-ui/README.md
+++ b/jquery-ui/README.md
@@ -1,6 +1,3 @@
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plugin allows you to use jQuery UI on each view descriptions.
 

--- a/jx-resources/README.md
+++ b/jx-resources/README.md
@@ -1,16 +1,6 @@
 This plugin exposes Pipeline run status to the Jenkins X
 PipelineActivity Custom Resources in Kuberentes
 
-| Plugin Information                                                                                    |
-|-------------------------------------------------------------------------------------------------------|
-| View JX Resources [on the plugin site](https://plugins.jenkins.io/jx-resources) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [CSRF vulnerability and missing permission
-    check](https://jenkins.io/security/advisory/2019-06-11/#SECURITY-1379)
-
 #  Configuration
 
 Refer to

--- a/kanboard/README.md
+++ b/kanboard/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                            |
-|-----------------------------------------------------------------------------------------------|
-| View Kanboard [on the plugin site](https://plugins.jenkins.io/kanboard) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [CSRF
-    vulnerability](https://jenkins.io/security/advisory/2019-01-28/#SECURITY-818)
 
 Allows users to create or update a [Kanboard](https://kanboard.net/)
 task as a post-build action, trigger a build when a task is created or

--- a/kiuwanJenkinsPlugin/README.md
+++ b/kiuwanJenkinsPlugin/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Reflected XSS
-    vulnerability](https://www.jenkins.io/security/advisory/2021-06-10/#SECURITY-2367)
 
 This plugin allows you to Run [Kiuwan](http://kiuwan.com/) static
 analysis of your code as part of your continuous integration process

--- a/klaros-testmanagement/README.md
+++ b/klaros-testmanagement/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-843)
 
 Integrates Jenkins with
 [Klaros-Testmanagement](http://www.klaros-testmanagement.com/) by

--- a/kmap-jenkins/README.md
+++ b/kmap-jenkins/README.md
@@ -1,21 +1,6 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [CSRF vulnerability and missing permission check allow
-    SSRF](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1055)
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1056)
 
 Publish mobile applications to your Keivox KMAP Private Mobile App Store
 [http://www.keivox.com](http://www.keivox.com/)
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [CSRF vulnerability and missing permission check allow
-    SSRF](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1055)
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1056)
 
 ## Installing the Keivox KMAP plugin
 

--- a/koji/README.md
+++ b/koji/README.md
@@ -1,14 +1,3 @@
-| Plugin Information                                                                    |
-|---------------------------------------------------------------------------------------|
-| View Koji [on the plugin site](https://plugins.jenkins.io/koji) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [SSL/TLS certificate validation globally and unconditionally
-    disabled](https://jenkins.io/security/advisory/2019-04-30/#SECURITY-936)
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1092)
 
 This plugin enables integration with
 [Koji](https://fedorahosted.org/koji/) build system providing clean-room

--- a/labmanager/README.md
+++ b/labmanager/README.md
@@ -1,12 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [SSL/TLS certificate validation globally and unconditionally
-    disabled](https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1376)
--   [CSRF vulnerability and missing permission
-    check](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-979)
--   [Password stored in plain
-    text](https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2084)
 
 Add VMware Lab Manager support to Jenkins
 

--- a/ldapemail/README.md
+++ b/ldapemail/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Plain text password shown in configuration
-    form](https://jenkins.io/security/advisory/2019-10-01/#SECURITY-1515)
 
 ## LDAP Email plugin
 

--- a/locale/README.md
+++ b/locale/README.md
@@ -1,10 +1,3 @@
-| Plugin Information                                                                        |
-|-------------------------------------------------------------------------------------------|
-| View Locale [on the plugin site](https://plugins.jenkins.io/locale) for more information. |
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plugin controls the language of JenkinsNormally, Jenkins honors the
 browser's language preference if a translation is available for the

--- a/locked-files-report/README.md
+++ b/locked-files-report/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Stored XSS
-    vulnerability](https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1921)
 
 This debug plugin fails a build if there are locked files in the
 workspace at the begining or end of a build.  

--- a/log-parser/README.md
+++ b/log-parser/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Stored XSS
-    vulnerability](https://jenkins.io/security/advisory/2019-09-25/#SECURITY-732)
 
 Parse the console output and highlight error/warning/info lines.
 

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                            |
-|-----------------------------------------------------------------------------------------------|
-| View Logstash [on the plugin site](https://plugins.jenkins.io/logstash) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials transmitted in plain
-    text](https://jenkins.io/security/advisory/2020-03-09/#SECURITY-1516)
 
 This plugin pushes logs and build data to a Logstash indexer such as
 Redis, RabbitMQ ElasticSearch, Logstash or Valo. 

--- a/m2release/README.md
+++ b/m2release/README.md
@@ -1,18 +1,3 @@
-| Plugin Information                                                                                          |
-|-------------------------------------------------------------------------------------------------------------|
-| View Maven Release Plug-in [on the plugin site](https://plugins.jenkins.io/m2release) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1435)
--   [Stored XSS
-    vulnerability](https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1184)
--   [XXE
-    vulnerability](https://jenkins.io/security/advisory/2019-12-17/#SECURITY-1681)
--   [CSRF
-    vulnerability](https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1098)
 
 This plugin allows you to perform a release build using the
 [maven-release-plugin](http://maven.apache.org/plugins/maven-release-plugin/)

--- a/mailcommander/README.md
+++ b/mailcommander/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Passwords stored in plain
-    text](https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2085)
 
 # Mail Commander Plugin
 

--- a/mantis/README.md
+++ b/mantis/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [CSRF
-    vulnerability](https://jenkins.io/security/advisory/2019-12-17/#SECURITY-1603)
 
 # Mantis Plugin
 

--- a/mattermost/README.md
+++ b/mattermost/README.md
@@ -1,10 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Webhook endpoint token stored in plain
-    text](https://jenkins.io/security/advisory/2019-10-23/#SECURITY-1628)
--   [SSRF
-    vulnerability](https://jenkins.io/security/advisory/2019-02-19/#SECURITY-985)
 
 Allows users to send build notifications to a self-hosted
 [Mattermost](http://www.mattermost.org/) installation

--- a/maven-release-cascade/README.md
+++ b/maven-release-cascade/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [CSRF vulnerability and missing permission
-    checks](https://www.jenkins.io/security/advisory/2020-10-08/#SECURITY-2049)
 
 #### Developed by
 

--- a/mesos/README.md
+++ b/mesos/README.md
@@ -1,15 +1,3 @@
-| Plugin Information                                                                            |
-|-----------------------------------------------------------------------------------------------|
-| View Mesos Cloud [on the plugin site](https://plugins.jenkins.io/mesos) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Server-side request forgery
-    vulnerability](https://jenkins.io/security/advisory/2018-09-25/#SECURITY-1013%20%282%29)
--   [Unprivileged users with Overall/Read access are able to enumerate
-    credential
-    IDs](https://jenkins.io/security/advisory/2018-09-25/#SECURITY-1013%20%281%29)
 
 The mesos-jenkins plugin allows Jenkins to dynamically launch Jenkins
 slaves on a Mesos cluster depending on the workload!Put simply, whenever

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -1,11 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Missing permission check allows unauthorized users to change
-    Metadata Plugin
-    configuration](https://jenkins.io/security/advisory/2018-09-25/#SECURITY-1135)
--   [Cross-Site Scripting
-    vulnerability](https://jenkins.io/security/advisory/2018-09-25/#SECURITY-1075)
 
 This plugin allows metadata to be added to projects, builds and slaves
 in Jenkins.  

--- a/minio-storage/README.md
+++ b/minio-storage/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-955)
 
 Allows users to upload build artifacts to a [Minio](https://minio.io/)
 server  

--- a/mission-control-view/README.md
+++ b/mission-control-view/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Stored XSS
-    vulnerability](https://jenkins.io/security/advisory/2019-12-17/#SECURITY-1592)
 
 Full screen dashboard view featuring job history, build queue, and
 current status of jobs and nodes.

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [CSRF vulnerability and missing permission
-    checks](https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1904)
 
 This plugin provides [MongoDB](http://www.mongodb.org/) integration
 capabilities.

--- a/mq-notifier/README.md
+++ b/mq-notifier/README.md
@@ -4,16 +4,6 @@ leaves the queue.
 By extending this plugin, developers can add events for when to send
 messages to MQ.
 
-| Plugin Information                                                                                  |
-|-----------------------------------------------------------------------------------------------------|
-| View MQ Notifier [on the plugin site](https://plugins.jenkins.io/mq-notifier) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [CSRF vulnerability and missing permission
-    checks](https://jenkins.io/security/advisory/2018-09-25/#SECURITY-972)
-
 ### General information
 
 The plugin connects to an MQ, e.g. RabbitMQ and sends messages during

--- a/nerrvana-plugin/README.md
+++ b/nerrvana-plugin/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                   |
-|------------------------------------------------------------------------------------------------------|
-| View Nerrvana [on the plugin site](https://plugins.jenkins.io/nerrvana-plugin) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [XXE
-    vulnerability](https://www.jenkins.io/security/advisory/2020-10-08/#SECURITY-2097)
 
 The Nerrvana Jenkins plugin allows you to automate functional and cross
 browser Selenium testing of your web applications in [Nerrvana

--- a/nested-view/README.md
+++ b/nested-view/README.md
@@ -1,12 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [XXE
-    vulnerability](https://www.jenkins.io/security/advisory/2021-08-31/#SECURITY-2411)
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 View type to allow grouping job views into multiple levels instead of
 one big list of tabs.

--- a/nomad/README.md
+++ b/nomad/README.md
@@ -1,10 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [CSRF vulnerability and missing permission check allow
-    SSRF](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1058)
--   [Password stored in plain
-    text](https://www.jenkins.io/security/advisory/2021-08-31/#SECURITY-2396)
 
   
 The Nomad Jenkins plugin allows Jenkins to dynamically launch build

--- a/oic-auth/README.md
+++ b/oic-auth/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Client secret displayed in plain
-    text](https://jenkins.io/security/advisory/2019-01-28/#SECURITY-886)
 
 [![](https://ci.jenkins.io/buildStatus/icon?job=Plugins/oic-auth-plugin/master){width="120"}  
 ![](http://sebastian-badge.info/plugins/oic-auth.svg){width="120"}  

--- a/open-stf/README.md
+++ b/open-stf/README.md
@@ -1,16 +1,6 @@
 Allows android developer to use android devices
 with [OpenSTF](http://openstf.io/)
 
-| Plugin Information                                                                            |
-|-----------------------------------------------------------------------------------------------|
-| View Open STF [on the plugin site](https://plugins.jenkins.io/open-stf) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Open STF Plugin stores credentials in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1059)
-
 ## Features
 
 Provides some features for Android development and testing with [The

--- a/openshift-deployer/README.md
+++ b/openshift-deployer/README.md
@@ -1,10 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [CSRF vulnerability and missing permission
-    check](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-981)
--   [Credentials transmitted in plain
-    text](https://jenkins.io/security/advisory/2020-03-09/#SECURITY-1518)
 
 # OpenShift Deployer Plugin 
 

--- a/openshift-pipeline/README.md
+++ b/openshift-pipeline/README.md
@@ -1,10 +1,4 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
 
--   [RCE
-    vulnerability](https://jenkins.io/security/advisory/2020-03-25/#SECURITY-1739)
-
-  
 
 Allows users to create jobs, pipelines, and workflows that operate with
 a Kubernetes based OpenShift server. [Source

--- a/oracle-cloud-infrastructure-compute-classic/README.md
+++ b/oracle-cloud-infrastructure-compute-classic/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [CSRF vulnerability and missing permission
-    check](https://jenkins.io/security/advisory/2019-10-16/#SECURITY-1462)
 
 A Jenkins Plugin to create compute instances on Oracle Cloud
 Infrastructure (OCI) Compute Classic and start agents on them

--- a/pam-auth/README.md
+++ b/pam-auth/README.md
@@ -1,18 +1,5 @@
 Adds Unix Pluggable Authentication Module (PAM) support to Jenkins.
 
-| Plugin Information                                                                                      |
-|---------------------------------------------------------------------------------------------------------|
-| View PAM Authentication [on the plugin site](https://plugins.jenkins.io/pam-auth) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Missing permission check allowed obtaining limited information
-    about system
-    configuration](https://jenkins.io/security/advisory/2019-05-21/#SECURITY-1316)
--   [Improper user account
-    validation](https://jenkins.io/security/advisory/2018-09-25/#SECURITY-813)
-
 ## Version History
 
 ### Version 1.6 (2019-10-08)

--- a/pangolin-testrail-connector/README.md
+++ b/pangolin-testrail-connector/README.md
@@ -9,19 +9,6 @@ The plugin allows users to
 integrate [TestRail](http://www.gurock.com/testrail/) into their CI
 workflow without writing a single line of code.
 
-| Plugin Information                                                                                                                                    |
-|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| View Agiletestware Pangolin Connector for TestRail [on the plugin site](https://plugins.jenkins.io/pangolin-testrail-connector) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [CSRF vulnerability and missing permission checks allowed overriding
-    plugin
-    configuration](https://jenkins.io/security/advisory/2018-07-30/#SECURITY-995)
-
-  
-
 ## Prerequisites
 
 -   [Pangolin

--- a/parasoft-findings/README.md
+++ b/parasoft-findings/README.md
@@ -1,12 +1,4 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
 
--   [XXE
-    vulnerability](https://jenkins.io/security/advisory/2020-04-16/#SECURITY-1753)
-
-  
-
-  
 
 Since 10.4.2 this plugin has been integrated with the [Warnings Next
 Generation

--- a/pathignore/README.md
+++ b/pathignore/README.md
@@ -1,6 +1,3 @@
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plugin allows SCM-triggered jobs to ignore build requests if only
 certain paths have changed, or to build if and only if certain paths are

--- a/pegdown-formatter/README.md
+++ b/pegdown-formatter/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Stored XSS
-    vulnerability](https://jenkins.io/security/advisory/2019-08-07/#SECURITY-142)
 
 [Features](http://localhost:8085/display/JENKINS/PegDown+Formatter+Plugin#PegDownFormatterPlugin-features)  
 [Compatibility](http://localhost:8085/display/JENKINS/PegDown+Formatter+Plugin#PegDownFormatterPlugin-compatibility)  

--- a/perfpublisher/README.md
+++ b/perfpublisher/README.md
@@ -1,10 +1,3 @@
-| Plugin Information                                                                                              |
-|-----------------------------------------------------------------------------------------------------------------|
-| View Performance Publisher [on the plugin site](https://plugins.jenkins.io/perfpublisher) for more information. |
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plugin generates global and trend reports for tests results
 analysis. Based on an open XML tests results format, the plugin parses

--- a/periodicbackup/README.md
+++ b/periodicbackup/README.md
@@ -1,16 +1,3 @@
-| Plugin Information                                                                                         |
-|------------------------------------------------------------------------------------------------------------|
-| View Periodic Backup [on the plugin site](https://plugins.jenkins.io/periodicbackup) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Missing permission checks and CSRF vulnerability in Periodic Backup
-    Plugin](https://jenkins.io/security/advisory/2017-07-10/)
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 ## Description
 

--- a/pipeline-aggregator-view/README.md
+++ b/pipeline-aggregator-view/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                                            |
-|-------------------------------------------------------------------------------------------------------------------------------|
-| View Pipeline Aggregator View [on the plugin site](https://plugins.jenkins.io/pipeline-aggregator-view) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Stored XSS
-    vulnerability](https://jenkins.io/security/advisory/2019-12-17/#SECURITY-1593)
 
 Allows the users to view the history of their pipelines with stage
 information (failed/In Progress/Passed) and the changes monitored)  

--- a/pipeline-githubnotify-step/README.md
+++ b/pipeline-githubnotify-step/README.md
@@ -1,10 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [CSRF vulnerability and missing permission checks allows capturing
-    credentials](https://jenkins.io/security/advisory/2020-02-12/#SECURITY-812%20(1))
--   [Users with Overall/Read access can enumerate credential
-    IDs](https://jenkins.io/security/advisory/2020-02-12/#SECURITY-812%20(2))
 
 This step allows a pipeline job to notify a status for any GitHub
 commit.

--- a/poll-mailbox-trigger-plugin/README.md
+++ b/poll-mailbox-trigger-plugin/README.md
@@ -1,11 +1,3 @@
-| Plugin Information                                                                                                           |
-|------------------------------------------------------------------------------------------------------------------------------|
-| View Poll Mailbox Trigger [on the plugin site](https://plugins.jenkins.io/poll-mailbox-trigger-plugin) for more information. |
-
-**This plugin is up for adoption.** The maintainer is looking for a
-co-maintainer. [Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
-
 A Jenkins plugin, to poll an email inbox, and trigger jobs based on new
 emails.
 

--- a/pollscm/README.md
+++ b/pollscm/README.md
@@ -1,16 +1,6 @@
 This plugin adds a Poll Now button to your job when Poll SCM option is
 enabled.
 
-| Plugin Information                                                                           |
-|----------------------------------------------------------------------------------------------|
-| View Poll SCM [on the plugin site](https://plugins.jenkins.io/pollscm) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [CSRF vulnerability allows
-    polling](https://jenkins.io/security/advisory/2017-07-10/)
-
 ## Changelog
 
 ### 1.3.1 (July 10, 2017)

--- a/port-allocator/README.md
+++ b/port-allocator/README.md
@@ -1,12 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-07-11/#SECURITY-1441)
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 # What does this do?
 

--- a/proc-cleaner-plugin/README.md
+++ b/proc-cleaner-plugin/README.md
@@ -1,15 +1,5 @@
 Eliminate running processes before or after build.
 
-| Plugin Information                                                                                              |
-|-----------------------------------------------------------------------------------------------------------------|
-| View Process cleaner [on the plugin site](https://plugins.jenkins.io/proc-cleaner-plugin) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Arbitrary code execution
-    vulnerability](https://jenkins.io/security/advisory/2017-04-10/)
-
 With this plugin user can decide to clean the processes either before or
 after the build. It can either kill all processes started by the user
 that runs Jenkins agent (except of that process) or all child processes

--- a/project-inheritance/README.md
+++ b/project-inheritance/README.md
@@ -1,20 +1,3 @@
-| Plugin Information                                                                                                  |
-|---------------------------------------------------------------------------------------------------------------------|
-| View Project Inheritance [on the plugin site](https://plugins.jenkins.io/project-inheritance) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Missing permission
-    check](https://jenkins.io/security/advisory/2020-06-03/#SECURITY-1582)
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Secret environment variables defined in Mask Passwords Plugin shown
-    unmasked](https://jenkins.io/security/advisory/2019-09-25/#SECURITY-351)
--   [CSRF vulnerability and missing permission
-    check](https://jenkins.io/security/advisory/2019-09-25/#SECURITY-401)
 
 The purpose of this plugin is to bring true inheritance of properties
 between multiple job definitions to Jenkins. This allows you to define

--- a/publish-over-cifs/README.md
+++ b/publish-over-cifs/README.md
@@ -1,19 +1,5 @@
 Send build artifacts to a windows share (CIFS/SMB/samba)
 
-| Plugin Information                                                                                              |
-|-----------------------------------------------------------------------------------------------------------------|
-| View Publish Over CIFS [on the plugin site](https://plugins.jenkins.io/publish-over-cifs) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [CSRF vulnerability and missing permission
-    checks](https://jenkins.io/security/advisory/2018-07-30/#SECURITY-975)
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
-
 # Publish Over ...
 
 Read Publish Over ... wiki page first

--- a/publish-over-ftp/README.md
+++ b/publish-over-ftp/README.md
@@ -1,10 +1,3 @@
-| Plugin Information                                                                                            |
-|---------------------------------------------------------------------------------------------------------------|
-| View Publish Over FTP [on the plugin site](https://plugins.jenkins.io/publish-over-ftp) for more information. |
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 # Publish Over ...
 

--- a/quality-gates/README.md
+++ b/quality-gates/README.md
@@ -1,10 +1,4 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
 
--   [Credentials transmitted in plain
-    text](https://jenkins.io/security/advisory/2020-03-09/#SECURITY-1519)
-
-  
 This plugin will fail the build whenever the Quality Gates criteria in
 the Sonar analysis aren't met (the project Quality Gates status is
 different than "Passed").

--- a/queue-cleanup/README.md
+++ b/queue-cleanup/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                      |
-|---------------------------------------------------------------------------------------------------------|
-| View Queue cleanup [on the plugin site](https://plugins.jenkins.io/queue-cleanup) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Reflected XSS
-    vulnerability](https://jenkins.io/security/advisory/2020-03-25/#SECURITY-1724)
 
 Remove stalled items waiting in Jenkins queue.Plugin allows
 administrator to configure queue wait timeout and item regex pattern.

--- a/rabbitmq-publisher/README.md
+++ b/rabbitmq-publisher/README.md
@@ -1,14 +1,3 @@
-| Plugin Information                                                                                                 |
-|--------------------------------------------------------------------------------------------------------------------|
-| View Rabbit-MQ Publisher [on the plugin site](https://plugins.jenkins.io/rabbitmq-publisher) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-03-06/#SECURITY-848)
--   [Server-side request
-    forgery](https://jenkins.io/security/advisory/2019-03-06/#SECURITY-970)
 
 ## Description
 

--- a/radargun/README.md
+++ b/radargun/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                            |
-|-----------------------------------------------------------------------------------------------|
-| View RadarGun [on the plugin site](https://plugins.jenkins.io/radargun) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [RCE
-    vulnerability](https://jenkins.io/security/advisory/2020-02-12/#SECURITY-1733)
 
 This plugin allows to run
 [RadarGun](https://github.com/radargun/radargun) benchmark as a Jenkins

--- a/radiatorviewplugin/README.md
+++ b/radiatorviewplugin/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Stored XSS
-    vulnerability](https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1927)
 
 Provides a job view displaying project status in a highly visible
 manner. This is ideal for displaying on a screen on the office wall as a

--- a/rebuild/README.md
+++ b/rebuild/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                            |
-|-----------------------------------------------------------------------------------------------|
-| View Rebuilder [on the plugin site](https://plugins.jenkins.io/rebuild) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Cross Site Scripting
-    vulnerability](https://jenkins.io/security/advisory/2018-09-25/#SECURITY-130)
 
 This plug-in allows the user to *rebuild* a *parametrized build* without
 entering the *parameters* again.It will also allow the user to edit the

--- a/redgate-sql-ci/README.md
+++ b/redgate-sql-ci/README.md
@@ -1,14 +1,3 @@
-| Plugin Information                                                                                                       |
-|--------------------------------------------------------------------------------------------------------------------------|
-| View Redgate SQL Change Automation [on the plugin site](https://plugins.jenkins.io/redgate-sql-ci) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-12-17/#SECURITY-1598)
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2020-01-15/#SECURITY-1696)
 
 ## Who is this plugin for?
 

--- a/relution-publisher/README.md
+++ b/relution-publisher/README.md
@@ -4,17 +4,6 @@
 This Plugin may be used to deploy build artefacts like iOS and Android
 apps to a [Relution Enterprise Appstore](http://www.relution.io/).
 
-  
-` `
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [CSRF vulnerability and missing permission check allow
-    SSRF](https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1053)
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-828)
-
 # relution-jenkins-plugin
 
 A Jenkins plugin for the [Relution Enterprise

--- a/remote-terminal-access/README.md
+++ b/remote-terminal-access/README.md
@@ -1,6 +1,3 @@
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 #### Table of Contents
 

--- a/requests/README.md
+++ b/requests/README.md
@@ -1,19 +1,5 @@
 Requests Plugin
 
-| Plugin Information                                                                                   |
-|------------------------------------------------------------------------------------------------------|
-| View requests-plugin [on the plugin site](https://plugins.jenkins.io/requests) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Missing permission check allows viewing pending
-    requests](https://www.jenkins.io/security/advisory/2021-06-30/#SECURITY-1995)
--   [Missing permission check allows sending
-    emails](https://www.jenkins.io/security/advisory/2021-06-30/#SECURITY-2136%20(2))
--   [CSRF
-    vulnerabilities](https://www.jenkins.io/security/advisory/2021-06-30/#SECURITY-2136%20(1))
-
 This plugin sets up a request center for non-admin users to be able to
 ask that their job to be deleted or renamed, or a build to be deleted or
 unlocked.

--- a/ruby-runtime/README.md
+++ b/ruby-runtime/README.md
@@ -1,6 +1,3 @@
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 Provides the Ruby runtime and bindings required to implement [plugins in
 Ruby](http://localhost:8085/display/JENKINS/Jenkins+plugin+development+in+Ruby).

--- a/run-condition-extras/README.md
+++ b/run-condition-extras/README.md
@@ -1,16 +1,3 @@
-| Plugin Information                                                                                                    |
-|-----------------------------------------------------------------------------------------------------------------------|
-| View Run Condition Extras [on the plugin site](https://plugins.jenkins.io/run-condition-extras) for more information. |
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
-
-  
-
-  
-
-  
 
 This plugin provides additional run conditions and integrations for [Run
 Condition

--- a/s3/README.md
+++ b/s3/README.md
@@ -1,14 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credential transmitted in plain
-    text](https://jenkins.io/security/advisory/2020-02-12/#SECURITY-1684)
--   [Missing permission
-    check](https://www.jenkins.io/security/advisory/2021-05-11/#SECURITY-2201)
--   [Missing permission checks allow obtaining metadata about
-    artifacts](https://www.jenkins.io/security/advisory/2021-05-11/#SECURITY-2200)
--   [Cross-site scripting vulnerability in artifact file
-    names](https://jenkins.io/security/advisory/2018-04-16/#SECURITY-730)
 
 Upload build artifacts to Amazon S3
 

--- a/sametime/README.md
+++ b/sametime/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1090)
 
 This plugin allows you to use
 [SameTime](http://www.ibm.com/lotus/sametime) as build notifier.

--- a/schedule-build/README.md
+++ b/schedule-build/README.md
@@ -2,14 +2,6 @@ Adds capability to schedule a build for a later point in time. Asks the
 user for a date and time and adds the build to the build queue with the
 respective quiet period.
 
-| Plugin Information                                                                                        |
-|-----------------------------------------------------------------------------------------------------------|
-| View Schedule Build [on the plugin site](https://plugins.jenkins.io/schedule-build) for more information. |
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
-
 # Scheduling Builds
 
 Press the "Schedule Build" link on the project page or use the schedule

--- a/scons/README.md
+++ b/scons/README.md
@@ -1,12 +1,4 @@
-| Plugin Information                                                                      |
-|-----------------------------------------------------------------------------------------|
-| View SCons [on the plugin site](https://plugins.jenkins.io/scons) for more information. |
 
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
-
-  
 This plugin allows Hudson to invoke [SCons](http://www.scons.org/) build
 script as the main build step.  
   

--- a/scp/README.md
+++ b/scp/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Insecure credential storage and
-    transmission](https://jenkins.io/security/advisory/2017-10-23/)
 
 This plugin uploads build artifacts to repository sites using SCP (SSH)
 protocol. First you should define SCP hosts on hudson global config

--- a/selection-tasks-plugin/README.md
+++ b/selection-tasks-plugin/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [System command execution
-    vulnerability](https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1967)
 
 This plugin adds new variable. You may select several tasks (for
 example, Selenium tests) for run.

--- a/selenium/README.md
+++ b/selenium/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                            |
-|-----------------------------------------------------------------------------------------------|
-| View Selenium [on the plugin site](https://plugins.jenkins.io/selenium) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Complete lack of CSRF protection can lead to OS command
-    injection](https://jenkins.io/security/advisory/2020-06-03/#SECURITY-1766)
 
 ![(warning)](docs/images/warning.svg)
 This plugin requires Jenkins to run under Java 8 or later as of version

--- a/seleniumhtmlreport/README.md
+++ b/seleniumhtmlreport/README.md
@@ -1,14 +1,3 @@
-| Plugin Information                                                                                                  |
-|---------------------------------------------------------------------------------------------------------------------|
-| View Selenium HTML report [on the plugin site](https://plugins.jenkins.io/seleniumhtmlreport) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [XXE
-    vulnerability](https://www.jenkins.io/security/advisory/2021-06-30/#SECURITY-2329)
-
-  
 
 This plugin visualizes the results of selenium tests.
 

--- a/shared-objects/README.md
+++ b/shared-objects/README.md
@@ -1,12 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [CSRF
-    vulnerability](https://www.jenkins.io/security/advisory/2020-10-08/#SECURITY-2052)
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plugin makes it possible to share objects (script file, source
 file, tool installation, ...) from an environment in Jenkins and manage

--- a/sidebar-link/README.md
+++ b/sidebar-link/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                    |
-|-------------------------------------------------------------------------------------------------------|
-| View Sidebar Link [on the plugin site](https://plugins.jenkins.io/sidebar-link) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Persisted XSS
-    Vulnerability](https://jenkins.io/security/advisory/2017-07-10/)
 
 Add links in the sidebar of the Jenkins main page, view tabs and project
 pages.This simple plugin adds an `Additional Sidebar Links` section in

--- a/sinatra-chef-builder/README.md
+++ b/sinatra-chef-builder/README.md
@@ -1,14 +1,3 @@
-| Plugin Information                                                                                            |
-|---------------------------------------------------------------------------------------------------------------|
-| View Chef Sinatra [on the plugin site](https://plugins.jenkins.io/sinatra-chef-builder) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [CSRF vulnerability and missing permission check allow
-    SSRF](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1037)
-
- 
 
 # **Summary****:**
 

--- a/sitemonitor/README.md
+++ b/sitemonitor/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                  |
-|-----------------------------------------------------------------------------------------------------|
-| View SiteMonitor [on the plugin site](https://plugins.jenkins.io/sitemonitor) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [SSL/TLS certificate validation globally and unconditionally
-    disabled](https://jenkins.io/security/advisory/2019-04-30/#SECURITY-930)
 
 Monitors web site up/down status.
 

--- a/skytap/README.md
+++ b/skytap/README.md
@@ -1,18 +1,3 @@
-| Plugin Information                                                                                 |
-|----------------------------------------------------------------------------------------------------|
-| View Skytap Cloud CI [on the plugin site](https://plugins.jenkins.io/skytap) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials transmitted in plain
-    text](https://jenkins.io/security/advisory/2020-03-09/#SECURITY-1522)
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-07-31/#SECURITY-1429)
 
 This plugin allows you to use Jenkins to run continuous integration and
 automated testing workflows using dynamically-created development and

--- a/slack-uploader/README.md
+++ b/slack-uploader/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Secret stored in plain
-    text](https://jenkins.io/security/advisory/2020-07-02/#SECURITY-1627)
 
 Allows users to upload files to [Slack](https://slack.com/)
 

--- a/sms/README.md
+++ b/sms/README.md
@@ -1,16 +1,3 @@
-``
-
-| Plugin Information                                                                               |
-|--------------------------------------------------------------------------------------------------|
-| View SMS Notification [on the plugin site](https://plugins.jenkins.io/sms) for more information. |
-
-` `
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Access token stored in plain
-    text](https://www.jenkins.io/security/advisory/2020-10-08/#SECURITY-2054)
 
 SMS Notification for failed Build, powered by Hoiio API
 ([http://www.hoiio.com](http://www.hoiio.com/))

--- a/sofy-ai/README.md
+++ b/sofy-ai/README.md
@@ -1,16 +1,4 @@
-| Plugin Information                                                                          |
-|---------------------------------------------------------------------------------------------|
-| View Sofy.AI [on the plugin site](https://plugins.jenkins.io/sofy-ai) for more information. |
 
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-10-16/#SECURITY-1431)
-
-  
-
-  
 This plugin allows you to conduct Tests for your Website and Mobile
 Application Builds, right from your Jenkins Pipelines, using your
 [Sofy](https://www.sofy.ai/) account

--- a/sonar-gerrit/README.md
+++ b/sonar-gerrit/README.md
@@ -17,12 +17,6 @@ report): <https://community.sonarsource.com/t/sonar-report-json-is-this-file-st
 The plugin shares [SonarQube](http://www.sonarqube.org/) feedback with
 developers via [Gerrit](https://code.google.com/p/gerrit/) tools.
 
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-10-23/#SECURITY-1003)
-
 # Requirements
 
 ## Jenkins

--- a/sonar/README.md
+++ b/sonar/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Server authentication token stored in plain
-    text](https://jenkins.io/security/advisory/2018-09-25/#SECURITY-1163)
 
 Documentation of SonarQube plugin available in SonarQube wiki
 

--- a/sqlplus-script-runner/README.md
+++ b/sqlplus-script-runner/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                                      |
-|-------------------------------------------------------------------------------------------------------------------------|
-| View SQLPlus Script Runner [on the plugin site](https://plugins.jenkins.io/sqlplus-script-runner) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Password written to the build
-    log](https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-2129)
 
 This plugin enables you run [Oracle
 SQL\*Plus](http://www.orafaq.com/wiki/SQL*Plus_FAQ) scripts on your

--- a/sra-deploy/README.md
+++ b/sra-deploy/README.md
@@ -12,12 +12,6 @@ The plugin currently supports
 -   Artifact upload to specified SRA repository
 -   Artifact deployment using specified SRA deployment process
 
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1066)
-
 # Pre-requisites
 
 This plugin currently supports the latest GA version of SRA. The plugin

--- a/ssh/README.md
+++ b/ssh/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                  |
-|-------------------------------------------------------------------------------------|
-| View SSH [on the plugin site](https://plugins.jenkins.io/ssh) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials are stored in unencrypted configuration
-    files](https://jenkins.io/security/advisory/2017-07-10/)
 
 ### Plugin info
 

--- a/starteam/README.md
+++ b/starteam/README.md
@@ -96,12 +96,6 @@ a Borland (MicroFocus0 cross-platform SCM solution.The plugin allows a
 jenkins project to be associated with a given StarTeam folder, in a
 given view and project.
 
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1085)
-
 The plugin currently supports the following:
 
 -   Checkout

--- a/storable-configs-plugin/README.md
+++ b/storable-configs-plugin/README.md
@@ -1,10 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Arbitrary file read
-    vulnerability](https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1968%20(1))
--   [Arbitrary file write
-    vulnerability](https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1968%20(2))
 
 This plugin allows you to save and load set of job parameters.
 

--- a/svn-partial-release-mgr/README.md
+++ b/svn-partial-release-mgr/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                                                     |
-|----------------------------------------------------------------------------------------------------------------------------------------|
-| View Subversion Partial Release Manager [on the plugin site](https://plugins.jenkins.io/svn-partial-release-mgr) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [XSS
-    vulnerability](https://jenkins.io/security/advisory/2020-06-03/#SECURITY-1726)
 
 This plugin provides the option to set up a job in Jenkins in order to
 build a partial release for a project.

--- a/tap/README.md
+++ b/tap/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                  |
-|-------------------------------------------------------------------------------------|
-| View TAP [on the plugin site](https://plugins.jenkins.io/tap) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Path traversal
-    vulnerability](https://jenkins.io/security/advisory/2016-06-20/)
 
 This plug-in adds support to [TAP](http://www.testanything.org/) test
 result files to Jenkins. It lets you specify an [ant-like

--- a/tattletale-plugin/README.md
+++ b/tattletale-plugin/README.md
@@ -1,13 +1,4 @@
 ﻿
-
-| Plugin Information                                                                                       |
-|----------------------------------------------------------------------------------------------------------|
-| View Tattletale [on the plugin site](https://plugins.jenkins.io/tattletale-plugin) for more information. |
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
-
 This plugin generates [Tattletale](http://www.jboss.org/tattletale)
 reports, mostly useful for jar file analysis.
 

--- a/testdroid-run-in-cloud/README.md
+++ b/testdroid-run-in-cloud/README.md
@@ -1,13 +1,3 @@
-| Plugin Information                                                                                                     |
-|------------------------------------------------------------------------------------------------------------------------|
-| View Bitbar Run-in-Cloud [on the plugin site](https://plugins.jenkins.io/testdroid-run-in-cloud) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Unprotected HTTP endpoint allowed server-side request forgery,
-    unauthorized configuration
-    changes](https://jenkins.io/security/advisory/2019-03-06/#SECURITY-1088)
 
 Enables easy integration between Jenkins CI and [Bitbar
 Testing](http://bitbar.com/). For further documentation please refer

--- a/testlink/README.md
+++ b/testlink/README.md
@@ -1,22 +1,3 @@
-| Plugin Information                                                                            |
-|-----------------------------------------------------------------------------------------------|
-| View TestLink [on the plugin site](https://plugins.jenkins.io/testlink) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-08-07/#SECURITY-1428)
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Stored cross-site scripting
-    vulnerability](https://jenkins.io/security/advisory/2018-02-26/#SECURITY-731)
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plug-in integrates Jenkins and [TestLink](http://testlink.org/) and
 generates reports on automated test execution. With this plug-in you can

--- a/testng-plugin/README.md
+++ b/testng-plugin/README.md
@@ -1,10 +1,3 @@
-| Plugin Information                                                                                       |
-|----------------------------------------------------------------------------------------------------------|
-| View TestNG Results [on the plugin site](https://plugins.jenkins.io/testng-plugin) for more information. |
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plugin allows you to publish TestNG results generated
 using `org.testng.reporters.XMLReporter`.TestNG result xml file contains

--- a/testopia/README.md
+++ b/testopia/README.md
@@ -1,6 +1,3 @@
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plug-in integrates **Jenkins** with Testopia and generates reports
 on automated test execution. With this plug-in you can manage your tests

--- a/tinfoil-scan/README.md
+++ b/tinfoil-scan/README.md
@@ -1,14 +1,3 @@
-| Plugin Information                                                                                        |
-|-----------------------------------------------------------------------------------------------------------|
-| View Tinfoil Security [on the plugin site](https://plugins.jenkins.io/tinfoil-scan) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Plugin stored API Secret Key in plain
-    text](https://jenkins.io/security/advisory/2018-07-30/#SECURITY-840)
-
-  
 
 # Tinfoil Security Plugin
 

--- a/trac-publisher-plugin/README.md
+++ b/trac-publisher-plugin/README.md
@@ -1,12 +1,6 @@
 This plug-in adds a publisher that posts build links to Trac tickets
 referenced in built scm revisions.
 
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-842)
-
 #### Changes
 
 -   1.3

--- a/translation/README.md
+++ b/translation/README.md
@@ -2,12 +2,6 @@
 this plugin is still useful for local translations, it's not possible to
 submit translations to the Jenkins project anymore.
 
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Cross-site request forgery (CSRF)
-    vulnerability](https://jenkins.io/security/advisory/2018-01-22/)
-
 This plugin adds an additional dialog box in every page, which enables
 people to contribute localizations for the messages they are seeing in
 the current page.This reduces the barrier of entry to localization, and

--- a/twitter/README.md
+++ b/twitter/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-30/#SECURITY-1143)
 
 This plugin posts build results to Twitter.Each Twitter update will
 contain build result, its build number, and job name. Optionally, the

--- a/valgrind/README.md
+++ b/valgrind/README.md
@@ -1,18 +1,3 @@
-  
-
-  
-
-| Plugin Information                                                                            |
-|-----------------------------------------------------------------------------------------------|
-| View Valgrind [on the plugin site](https://plugins.jenkins.io/valgrind) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Stored XSS
-    vulnerability](https://jenkins.io/security/advisory/2020-09-01/#SECURITY-1830)
--   [XXE
-    vulnerability](https://jenkins.io/security/advisory/2020-09-01/#SECURITY-1829)
 
 Integrates [Valgrind](http://www.valgrind.org/) in Jenkins.This Plugin
 integrates [Valgrind](http://www.valgrind.org/) (memcheck to be exact)

--- a/vault-scm-plugin/README.md
+++ b/vault-scm-plugin/README.md
@@ -8,16 +8,6 @@ if there is changes and keeping the changelog.
 This is an unofficial plugin - neither the plugin or the developer are
 affiliated with SourceGear.
 
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Plain text password shown in configuration
-    form](https://jenkins.io/security/advisory/2019-10-01/#SECURITY-1524)
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
-
 # Basic Usage
 
 Once this plugin is installed, you'll see SourceGear Vault as one of the

--- a/versionnumber/README.md
+++ b/versionnumber/README.md
@@ -1,10 +1,3 @@
-| Plugin Information                                                                                       |
-|----------------------------------------------------------------------------------------------------------|
-| View Version Number [on the plugin site](https://plugins.jenkins.io/versionnumber) for more information. |
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plugin creates a new version number and stores it in the
 environment variable whose name you specify in the configuration.

--- a/view26/README.md
+++ b/view26/README.md
@@ -1,16 +1,3 @@
- 
-
- 
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-10-16/#SECURITY-1440)
-
- 
-
- 
 
 This add-on will collect JUnit test results from your builds and submit
 them as Test Runs and Test Logs to VIEW26. The view26 plugin supports

--- a/virtualbox/README.md
+++ b/virtualbox/README.md
@@ -1,10 +1,3 @@
-| Plugin Information                                                                                |
-|---------------------------------------------------------------------------------------------------|
-| View VirtualBox [on the plugin site](https://plugins.jenkins.io/virtualbox) for more information. |
-
-**This plugin is up for adoption.** Proposing a new maintainer to
-support plugin. [Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
 
 This plugin integrates Jenkins with
 [VirtualBox](http://www.virtualbox.org/) (version 3, 4.0, 4.1, 4.2 and

--- a/visualworks-store/README.md
+++ b/visualworks-store/README.md
@@ -3,12 +3,6 @@ Visualworks](http://cincomsmalltalk.com/) Smalltalk Store.  The plugin
 requires at least one shell script or batch file to be created that can
 run a Visualworks image with the StoreCI-Polling package loaded.
 
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [XXE
-    vulnerability](https://www.jenkins.io/security/advisory/2020-11-04/#SECURITY-1900)
-
 # Using the Visualworks Store Plugin
 
 In order to use the Visualworks Store Plugin, a few steps are required.

--- a/vmware-vrealize-automation-plugin/README.md
+++ b/vmware-vrealize-automation-plugin/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-945)
 
 Provides Jenkins integration with [vRealize Automation
 7.x](https://www.vmware.com/products/vrealize-automation)  

--- a/vncrecorder/README.md
+++ b/vncrecorder/README.md
@@ -1,10 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Reflected XSS
-    vulnerability](https://jenkins.io/security/advisory/2020-07-02/#SECURITY-1728%20(2))
--   [Stored XSS
-    vulnerability](https://jenkins.io/security/advisory/2020-07-02/#SECURITY-1728%20(1))
 
 This plugin records screen of current build or other configured VNC
 session as Shock Wave Flash (swf) file during a build and stores it as

--- a/vncviewer/README.md
+++ b/vncviewer/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Reflected XSS
-    vulnerability](https://jenkins.io/security/advisory/2020-07-02/#SECURITY-1776)
 
 VncViewer lets you monitor or operate GUI of your running build. You can
 start HTML5 based VNC viewer via HTML link directly from 'Console

--- a/vsts-cd/README.md
+++ b/vsts-cd/README.md
@@ -4,12 +4,3 @@ The use of this plugin is now **deprecated**. The functionality of this
 plugin has been moved to [TFS
 plugin](https://wiki.jenkins-ci.org/display/JENKINS/Team+Foundation+Server+Plugin)
 with enhanced functionality. 
-
-  
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [VS Team Services Continuous Deployment Plugin stores credentials in
-    plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-962)

--- a/weblogic-deployer-plugin/README.md
+++ b/weblogic-deployer-plugin/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                                   |
-|----------------------------------------------------------------------------------------------------------------------|
-| View Deploy WebLogic [on the plugin site](https://plugins.jenkins.io/weblogic-deployer-plugin) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [CSRF vulnerability and missing permission
-    check](https://jenkins.io/security/advisory/2019-10-23/#SECURITY-820)
 
 This plugin deploys any artifacts built on Jenkins to a weblogic target
 (managed server, cluster ...) as an application or a library component.

--- a/websphere-deployer/README.md
+++ b/websphere-deployer/README.md
@@ -1,18 +1,3 @@
-| Plugin Information                                                                                                |
-|-------------------------------------------------------------------------------------------------------------------|
-| View WebSphere Deployer [on the plugin site](https://plugins.jenkins.io/websphere-deployer) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [SSL/TLS certificate validation globally and unconditionally
-    disabled](https://jenkins.io/security/advisory/2019-12-17/#SECURITY-1581)
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-956)
--   [CSRF vulnerability and missing permission
-    checks](https://jenkins.io/security/advisory/2019-12-17/#SECURITY-1371)
--   [XXE
-    vulnerability](https://jenkins.io/security/advisory/2020-01-29/#SECURITY-1719)
 
 This is a collection of two separate plugins that provide deployment
 functionality to most versions of IBM WebSphere Application Server, IBM

--- a/weibo/README.md
+++ b/weibo/README.md
@@ -1,14 +1,3 @@
-| Plugin Information                                                                      |
-|-----------------------------------------------------------------------------------------|
-| View Weibo [on the plugin site](https://plugins.jenkins.io/weibo) for more information. |
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-12-17/#SECURITY-1597)
-
-  
 
 This plugin allow you to post customized message to Sina microblog.
 

--- a/whitesource/README.md
+++ b/whitesource/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                                   |
-|------------------------------------------------------------------------------------------------------|
-| View White Source [on the plugin site](https://plugins.jenkins.io/whitesource) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2020-07-02/#SECURITY-1630)
 
 The plugin brings automatic open source management to Jenkins users.
 

--- a/wildfly-deployer/README.md
+++ b/wildfly-deployer/README.md
@@ -1,8 +1,3 @@
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-961)
 
 This plugin deploys applications (WAR or EAR files) to a WildFly or
 JBoss EAP server or server group.

--- a/wix/README.md
+++ b/wix/README.md
@@ -27,12 +27,6 @@ Versions prior to **1.11** do not work properly because they use
 absolute file paths or missing the full usage of Jenkins internal
 process launcher.
 
-------------------------------------------------------------------------
-
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
-
 # Pre-requisites
 
 Additional to this plugin you have to download and install [WIX

--- a/workflow-remote-loader/README.md
+++ b/workflow-remote-loader/README.md
@@ -1,8 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Unsafe entry in Script Security list of approved
-    signatures](https://jenkins.io/security/advisory/2019-05-31/#SECURITY-921)
 
 Allows loading [Pipeline](https://github.com/jenkinsci/workflow-plugin)
 scripts from remote locations (enhanced version of the built-in load

--- a/youtrack-plugin/README.md
+++ b/youtrack-plugin/README.md
@@ -1,10 +1,3 @@
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-963)
--   [Arbitrary code execution
-    vulnerability](https://jenkins.io/security/advisory/2017-04-10/)
 
 This plugin provides some integration with
 [YouTrack](http://jetbrains.com/youtrack). This version (0.7.x) has

--- a/zap/README.md
+++ b/zap/README.md
@@ -37,12 +37,6 @@ You can also:
         **.xml**[![](docs/images/xml.png)](http://www.w3schools.com/xml/default.asp),
         **.json**[![](docs/images/json.png)](http://www.w3schools.com/js/js_json_intro.asp))
 
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-04-03/#SECURITY-1041)
-
 ### Table of Contents
 
 -   [ZAP as a part of a CI

--- a/zentimestamp/README.md
+++ b/zentimestamp/README.md
@@ -1,7 +1,3 @@
-**This plugin is up for adoption.** Want to help improve this plugin?
-[Click here to learn
-more](http://localhost:8085/display/JENKINS/Adopt+a+Plugin "Adopt a Plugin")!
-
 This plugin export a `BUILD_TIMESTAMP` variable.
 
 # Description

--- a/zephyr-for-jira-test-management/README.md
+++ b/zephyr-for-jira-test-management/README.md
@@ -5,16 +5,6 @@ Creates test cases and publishes test results in [Zephyr for
 JIRA](http://www.getzephyr.com/products/test-management-add-ons-for-atlassian)
 for JUnit test cases
 
-  
-
-The current version of this plugin may not be safe to use. Please review
-the following warnings before use:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2020-03-09/#SECURITY-1550)
--   [CSRF vulnerability and missing permission
-    checks](https://jenkins.io/security/advisory/2020-07-02/#SECURITY-1762)
-
 ## **About the Plugin**
 
 Zephyr for JIRA Plugin for Jenkins integrates Jenkins and Zephyr for

--- a/zulip/README.md
+++ b/zulip/README.md
@@ -1,12 +1,3 @@
-| Plugin Information                                                                      |
-|-----------------------------------------------------------------------------------------|
-| View Zulip [on the plugin site](https://plugins.jenkins.io/zulip) for more information. |
-
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Credentials stored in plain
-    text](https://jenkins.io/security/advisory/2019-10-23/#SECURITY-1621)
 
 This plugin provides integration between Jenkins and Zulip. It allows
 you to send messages and notifications of build statuses from Jenkins


### PR DESCRIPTION
I'm sure we don't want to normalize pull requests to this repo, instead preferring migration, but given that well-meaning but clueless contributors may just copy this content into readmes when it really shouldn't be there, I thought it was best to remove it from the source.

See e.g. https://github.com/search?q=org%3Ajenkinsci+%22Older+versions+of+this+plugin+may+not+be+safe+to+use%22&type=code for examples of this having happened.
