### PR TITLE
Deprecate the unleash plugin

### DIFF
--- a/unleash/README.md
+++ b/unleash/README.md
@@ -1,6 +1,14 @@
+# Unleash plugin - **Deprecated**
+
 This is a Jenkins Build Wrapper for Maven Jobs. It enables you to
 perform Maven releases using the
 [unleash-maven-plugin](https://github.com/shillner/unleash-maven-plugin).
+
+# **DEPRECATED**
+
+**This plugin is deprecated.**
+The [Apache Maven unleash plugin](https://github.com/shillner/unleash-maven-plugin) is no longer being developed.
+Users should move to other maven release processes, like the [Apache Maven release plugin](https://maven.apache.org/guides/mini/guide-releasing.html).
 
 # How To Use The Plugin?
 


### PR DESCRIPTION
## Deprecate the unleash plugin

https://github.com/shillner/unleash-maven-plugin/ has been archived.  That is the unleash plugin for Apache Maven.  The Jenkins unleash maven plugin depends on the unleash plugin for Apache Maven.

https://github.com/jenkinsci/unleash-plugin has been archived.  That is the Jenkins unleash Maven plugin. The last release of the Jenkins unleash maven plugin was 3 years ago. Since the Jenkins plugin repository has been archived, we can expect no new releases of the plugin.

[JENKINS-70326](https://issues.jenkins.io/browse/JENKINS-70326) notes that the Jenkins unleash maven plugin does not work with Java 17.

Let's deprecate the Jenkins plugin so that it is clear to users that the Jenkins plugin is not being maintained and that the Apache Maven plugin is not being maintained.

https://www.jenkins.io/doc/developer/plugin-governance/deprecating-or-removing-plugin/ says that the preferred way to deprecate a plugin is to add the "deprecated" topic to the repository and to explain in the plugin documentation why it is being deprecated.  That would mean allowing writes to the repository again, just long enough to set the topic.

I assume that is more complicated than the alternate method, a pull request to the update center repository to mark the repository as deprecated.

https://github.com/jenkins-infra/repository-permissions-updater/pull/3042 is the request to remove all developers from the archived plugin repository.
