### PR TITLE
Deprecate GitHub Pull Request Builder plugin

### DIFF
--- a/ghprb/README.md
+++ b/ghprb/README.md
@@ -1,7 +1,12 @@
-You should probably migrate to [GitHub Branch Source
-Plugin](https://wiki.jenkins.io/display/JENKINS/GitHub+Branch+Source+Plugin)
+# GitHub Pull Request Builder
 
-This plugin builds pull requests in github and report results.
+This plugin builds GitHub pull requests and reports results.
+
+## Deprecated
+
+This plugin is **deprecated**. It has been replaced by the [GitHub Branch Source Plugin](https://plugins.jenkins.io/github-branch-source/). It has known security vulnerabilities and is no longer being maintained. Users should migrate to the [GitHub Branch Source Plugin](https://plugins.jenkins.io/github-branch-source/).
+
+## Deprecated
 
 More **up to date** information is available on the:  
 [Github


### PR DESCRIPTION
## Deprecate GitHub Pull Request Builder plugin

The GitHub Pull Request Builder plugin should be deprecated so that users do not mistakenly install it when integrating with GitHub.

More details are available in Jenkins infrastructure help desk ticket:

* https://github.com/jenkins-infra/helpdesk/issues/4608

The deprecation message is being added here because a new release of the plugin would be required in order to move documentation to the plugin GitHub repository.  We don't want a new release of the plugin just to declare it deprecatd.

A similar message will be proposed for the README in the plugin repository.
